### PR TITLE
chore: sync up the post-term styles with block canvas

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -203,6 +203,20 @@
 					"fontSize": "var(--wp--preset--font-size--small)"
 				}
 			},
+			"core/post-terms": {
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						},
+						":hover": {
+							"typography": {
+								"textDecoration": "underline"
+							}
+						}
+					}
+				}
+			},
 			"core/post-title": {
 				"elements": {
 					"link": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I'll need to come up with a better process for this, but this PR is to sync a [recent change in Block Canvas](https://github.com/Automattic/themes/pull/7058) to this theme that removes the underline styles from the post terms block until they're hovered over.

We may not want to copy over every change to Block Canvas, but things like this (styles we'll want, at least in some form), or changes that indicate changes coming to the block editor are super helpful to track and add.

### How to test the changes in this Pull Request:

1. View a single post and scroll to the bottom; note the category and tag appearance.

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/2fb3c4e8-e41c-4df8-bbad-bdcc511ded72)

2. Apply the PR.
3. Refresh the post and confirm that the underlines are gone until you hover over the tags or category. 

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/a352dd02-cb4c-462a-8086-a910ad7a6f27)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
