### PR TITLE
fix: remove unnecessary spacing from navigation menu

### DIFF
--- a/src/scss/_gutenberg-shim.scss
+++ b/src/scss/_gutenberg-shim.scss
@@ -16,6 +16,17 @@
 }
 
 /*
+ * Navigation styles
+ * Remove extra padding from navigation link when set to click to open.
+ * https://github.com/WordPress/gutenberg/issues/50722
+ */
+ .wp-block-navigation {
+	.wp-block-navigation-item.open-on-click .wp-block-navigation-submenu__toggle {
+		padding-left: 0;
+	}
+}
+
+/*
  * Link styles
  * https://github.com/WordPress/gutenberg/issues/42319
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a minor alignment issue with the Navigation menu, and can be removed once there's a fix for https://github.com/WordPress/gutenberg/issues/50722.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
