### PR TITLE
feat: add front page template

### DIFF
--- a/templates/front-page.html
+++ b/templates/front-page.html
@@ -1,0 +1,19 @@
+<!-- wp:template-part {"slug":"header","tagName":"header","theme":"newspack-block-theme"} /-->
+
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true}} -->
+<main class="wp-block-group">
+	<!-- wp:post-featured-image {"align":"full"} /-->
+	<!-- wp:post-content {"layout":{"type":"constrained"},"lock":{"move":false,"remove":true}} /-->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+	<!-- wp:spacer {"height":60} -->
+	<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+	<!-- /wp:spacer -->
+	<!-- wp:pattern {"slug":"newspack-block-theme/comments"} /-->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer","theme":"newspack-block-theme"} /-->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adding a front-page.html that will automatically be applied to a static front page. 

Unlike the other templates, the base of this one is 'wide' (which may not make sense -- I'll revisit that), and it doesn't have a page title.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
