### PR TITLE
feat: add greys from WordPress to custom variables

### DIFF
--- a/src/scss/_header.scss
+++ b/src/scss/_header.scss
@@ -18,8 +18,8 @@
 }
 
 .mobile-sidebar {
-	background: var( --wp--custom--background--mobile-menu );
-	color: var( --wp--custom--color--mobile-menu );
+	background: var( --wp--custom--color--mobile-menu-background );
+	color: var( --wp--custom--color--mobile-menu-text );
 	inset: 0 -100% 0 auto;
 	opacity: 0;
 	overflow: auto;

--- a/theme.json
+++ b/theme.json
@@ -141,12 +141,18 @@
 		},
 		"useRootPaddingAwareAlignments": true,
 		"custom": {
-			"background": {
-				"mobile-menu": "var( --wp--preset--color--contrast )",
-				"mobile-menu-overlay": "rgba( 0, 0, 0, 0.5 )"
-			},
 			"color": {
-				"mobile-menu": "var( --wp--preset--color--base )"
+				"gray-900": "#1e1e1e",
+				"gray-800": "#2f2f2f",
+				"gray-700": "#757575",
+				"gray-600": "#949494",
+				"gray-400": "#ccc",
+				"gray-300": "#ddd",
+				"gray-200": "#e0e0e0",
+				"gray-100": "#f0f0f0",
+				"mobile-menu-text": "var( --wp--preset--color--contrast )",
+				"mobile-menu-background": "var( --wp--custom--color--gray-900 )",
+				"mobile-menu-overlay": "rgba( 0, 0, 0, 0.5 )"
 			},
 			"line-height": {
 				"x-small": "1.5",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR acts as at least a temporary solution to the question, "How to handle the greys in the mockups?"

More details: In the mockups, Thomas included a few different WordPress greys (listed [here](https://github.com/WordPress/gutenberg/blob/c34280bbf0593f4bf0bc24b210bfe42afb61e119/packages/base-styles/_colors.scss#L11)); a couple of them do exist in the default palette, but they're used in ways that we may not want them overridden so easily by changing the site's colours. 

The specific values I added are:

```
$gray-900`: #1e1e1e;
$gray-800: #2f2f2f;
$gray-700: #757575;
$gray-600: #949494;
$gray-400: #ccc;
$gray-300: #ddd;		
$gray-200: #e0e0e0;	
$gray-100: #f0f0f0;	
```

They MAY be something we want publishers to be able to edit down the road; in that case, this approach may not be the best. But for now, for establishing some default styles, it's a good starting point.

What would be ideal is if we could add a grey palette separate from the custom colours set from the theme; even if they're editable, it could help separate them from the rest and make it a little easier to tell if you should be changing them. 

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
