### PR TITLE
fix: remove style that doesn't work from theme.json

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -413,13 +413,6 @@
 							}
 						}
 					}
-				},
-				"variations": {
-					"category": {
-						"typography": {
-							"fontWeight": "bold"
-						}
-					}
 				}
 			},
 			"core/post-title": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes a not-working style from the theme.json that was also throwing PHP warnings ('category' isn't considered a block variation of post-terms, and can't be styled as such).

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
