### PR TITLE
feat: add copyright symbol to footer

### DIFF
--- a/parts/footer.html
+++ b/parts/footer.html
@@ -35,10 +35,16 @@
 <!-- /wp:separator -->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group"><!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph {"fontSize":"x-small"} -->
+<p class="has-x-small-font-size"><strong>©</strong></p>
+<!-- /wp:paragraph -->
 
-<!-- wp:paragraph {"textColor":"base","fontSize":"x-small"} -->
-<p class="has-base-color has-text-color has-x-small-font-size"><a href="https://newspack.com">Proudly powered by Newspack by Automattic</a></p>
+<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"textColor":"base","fontSize":"x-small"} -->
+<p class="has-base-color has-text-color has-link-color has-x-small-font-size"><a href="https://newspack.com">Proudly powered by Newspack by Automattic</a></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a small PR that adds the copyright symbol to the correct space in the initial footer pattern. 

Ideally this will be replaced with a block that contains the site name, the copyright symbol, and current year, plus the ability to augment it (eg. change the site name text; add a date range. etc.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
