### PR TITLE
feat: change search block's default settings

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -93,7 +93,7 @@ final class Core {
 	 *
 	 * @since Newspack Block Theme 1.0
 	 *
-	 * This is a bit clunky, but we'll be able to replace it with JavaScript once isDefault works there.
+	 * We may be able to replace this with JavaScript; I'm unclear whether isDefault isn't working, or just not working as I expect it to.
 	 * See: https://github.com/WordPress/gutenberg/issues/28119
 	 *
 	 * @return array Block metadata.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR changes the default appearance of the search block, from:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/24de0f15-3c50-4b0f-801a-8229e4db9e8f)

... to:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/4e0fe83a-93e0-47db-9749-48662130984f)

I've used PHP to do this, but I think the "correct" way would be to use JavaScript, [block variations](https://fullsiteediting.com/lessons/block-variations/), and the `isDefault` setting. Unfortunately the last one [either isn't working with block variations, or isn't working the way I expect it to](https://github.com/WordPress/gutenberg/issues/28119).

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Add a search block, either through the site editor or page/post editor.
3. Confirm that it has the following default settings:
   * Button inside
   * Button uses an icon
   * No label
   * Placeholder set to "Search...".
4. Try changing those options and confirm that the block lets you edit them as usual. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
