### PR TITLE
feat: add a clamp to the larger spacing sizes

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -76,17 +76,17 @@
 				},
 				{
 					"name": "5",
-					"size": "3.75rem",
+					"size": "clamp(2.625rem, 1.984rem + 2.848vw, 3.75rem)",
 					"slug": "60"
 				},
 				{
 					"name": "6",
-					"size": "5.625rem",
+					"size": "clamp(3.75rem, 2.682rem + 4.747vw, 5.625rem)",
 					"slug": "70"
 				},
 				{
 					"name": "7",
-					"size": "7.5rem",
+					"size": "clamp(5.625rem, 4.557rem + 4.747vw, 7.5rem)",
 					"slug": "80"
 				}
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a clamp for the highest spacing values that follows the breakpoints established in the design for typography (360px to 992px).

The sizes are:

7: Maximum 120px; minimum 90px
6: Maximum 90px; minimum 60px
5: Maximum 60px; minimum 42px

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
