### PR TITLE
feat: maybe remove core template parts and reclassify header parts

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -56,6 +56,9 @@ final class Core {
 
 		// Make theme available for translation.
 		\load_theme_textdomain( 'newspack-block-theme' );
+
+		// Unregister default block patterns
+		\remove_theme_support( 'core-block-patterns' );
 	}
 
 	/**

--- a/theme.json
+++ b/theme.json
@@ -688,21 +688,11 @@
 	"templateParts": [
 		{
 			"area": "header",
-			"name": "header",
-			"title": "Header"
-		},
-		{
-			"area": "uncategorized",
 			"name": "mobile-header",
 			"title": "Mobile Header"
 		},
 		{
-			"area": "uncategorized",
-			"name": "mobile-sidebar",
-			"title": "Mobile Sidebar"
-		},
-		{
-			"area": "uncategorized",
+			"area": "header",
 			"name": "desktop-header",
 			"title": "Desktop Header"
 		},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR's a little future facing and not required for the MVP -- I'm kind of thinking ahead to how things like the header and footer will work going forward:

The 'Header' and 'Footer' template part designations let you do a straight swap for other ones that are available in the theme, or in the Core patterns. Once the template part is selected you can use the `...` menu to 'Replace' the header or footer:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/bd4a39cc-65c9-4bae-ad7f-d3c3c7f6c3db)

... and then you get a popup of theme-based and core-based header template parts and patterns:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/19b9e460-d8f2-4d2c-be7b-7c0e0e9f587d)

Because we're kind of crafting a weird way to wrangle the header especially, I wonder if we should remove all core patterns, and only populate the theme with our own header patterns. Then, if we only call the desktop header and mobile header parts 'Headers' in the theme.json, they'll be the only ones that appear in that popup. With this PR it's a bit sparse, but it would look like:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/32384357-4753-4c40-8156-b66a80419536)

This PR is a bit of a all-or-nothing option -- it removes ALL core patterns, including ones for the content. In reality, we may want to only cherry pick the header ones, since they're the ones specifically that won't work as well with the way we set up the header (the downside here is that it looks like we'll need to specify them all by name, it doesn't look like we can just remove a category 😕 ).

I'd appreciate some thoughts on this as well as just a run through to see how it works, and whether it makes sense to go SO nuclear with the core patterns.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Edit the site, and select the 'Desktop Header' template part. 
3. Click the `...` menu then "Replace Desktop Header".
4. See the popup; observe the limited options. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
