### PR TITLE
fix: remove IDs from navigation blocks

### DIFF
--- a/parts/desktop-header.html
+++ b/parts/desktop-header.html
@@ -18,7 +18,7 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignwide"><!-- wp:navigation {"ref":13,"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
+<div class="wp-block-group alignwide"><!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"0"}}}} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -22,7 +22,7 @@
 <!-- wp:social-link {"url":"#","service":"youtube"} /--></ul>
 <!-- /wp:social-links -->
 
-<!-- wp:navigation {"ref":13,"overlayMenu":"never","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
+<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","flexWrap":"wrap"}} /--></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"width":"33.33%"} -->

--- a/parts/mobile-sidebar.html
+++ b/parts/mobile-sidebar.html
@@ -11,7 +11,7 @@
 <hr class="wp-block-separator has-text-color has-tertiary-color has-alpha-channel-opacity has-tertiary-background-color has-background"/>
 <!-- /wp:separator -->
 
-<!-- wp:navigation {"ref":146,"overlayMenu":"never","className":"is-style-flatten","layout":{"type":"flex","setCascadingProperties":true,"orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
+<!-- wp:navigation {"overlayMenu":"never","className":"is-style-flatten","layout":{"type":"flex","setCascadingProperties":true,"orientation":"vertical"},"style":{"spacing":{"margin":{"top":"0"}}}} /-->
 
 <!-- wp:separator {"backgroundColor":"tertiary"} -->
 <hr class="wp-block-separator has-text-color has-tertiary-color has-alpha-channel-opacity has-tertiary-background-color has-background"/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the hard-coded menu IDs from the navigation blocks used in the theme so far, to prevent the "this menu doesn't exist" menu when the theme is used on other sites. 

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
