### PR TITLE
fix: hide author, date for pages in search

### DIFF
--- a/src/scss/_gutenberg-shim.scss
+++ b/src/scss/_gutenberg-shim.scss
@@ -65,7 +65,6 @@ figcaption a {
  * Search styles
  * Hide date and byline for pages; may want to flip this in the future to all but posts.
  */
-
 .search-results {
 	.type-page {
 		.wp-block-post-author,
@@ -74,8 +73,6 @@ figcaption a {
 		}
 	}
 }
-
-
 
 /*
  * Form Styles


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now search results will show authors and dates for all post types.

This is meh for some of them, but particularly suboptimal for pages. 

While it's unlikely our publishers will see this since most use Jetpack Instant search, this PR hides those two elements when a post type is a page. 

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
