### PR TITLE
feat: add large image single post variation

### DIFF
--- a/templates/single/large-image.html
+++ b/templates/single/large-image.html
@@ -1,0 +1,35 @@
+<!-- wp:template-part {"slug":"header","theme":"newspack-block-theme","tagName":"header"} /-->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:template-part {"slug":"post-header","theme":"newspack-block-theme","area":"uncategorized"} /-->
+
+<!-- wp:separator {"backgroundColor":"quartary"} -->
+<hr class="wp-block-separator has-text-color has-quartary-color has-alpha-channel-opacity has-quartary-background-color has-background"/>
+<!-- /wp:separator --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"layout":{"type":"constrained","wideSize":"960px"}} -->
+<main class="wp-block-group"><!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60","top":"var:preset|spacing|60"}}}} /--></main>
+<!-- /wp:group -->
+
+<!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /-->
+
+<!-- wp:template-part {"slug":"post-footer","theme":"newspack-block-theme"} /-->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:template-part {"slug":"author-bio","theme":"newspack-block-theme"} /-->
+
+<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
+<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></main>
+<!-- /wp:group -->
+
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:template-part {"slug":"comments","theme":"newspack-block-theme"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"newspack-block-theme","tagName":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -685,6 +685,15 @@
 			"lineHeight": "1.6667"
 		}
 	},
+	"customTemplates": [
+		{
+			"name": "single/large-image",
+			"postTypes": [
+				"post"
+			],
+			"title": "Single - Large Image"
+		}
+	],
 	"templateParts": [
 		{
 			"area": "header",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a bit of a "box ticking" PR for the MVP, but it adds an example of an alternative template for the single posts.

I think before we get too far into these it would be good to establish a naming convention/folder structure. 

Only post types can really change templates -- for auto-generated pages like archives, search and 404, we'll need to use block patterns. 

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
