### PR TITLE
feat: add archive layout through block pattern

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -42,6 +42,7 @@ final class Core {
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'theme_styles' ] );
 		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'editor_scripts' ] );
 		\add_filter( 'block_type_metadata', [ __CLASS__, 'block_variations' ] );
+		\add_action( 'init', [ __CLASS__, 'block_pattern_categories' ] );
 	}
 
 	/**
@@ -107,6 +108,22 @@ final class Core {
 		}
 		return $metadata;
 	}
+
+	/**
+	 * Add block pattern categories.
+	 *
+	 * @since Newspack Block Theme 1.0
+	 */
+	public static function block_pattern_categories() {
+		register_block_pattern_category(
+			'newspack-block-theme',
+			array(
+				'label' => __( 'Newspack Block Theme', 'text-domain' ),
+				'description' => __( 'Patterns bundled with the Newspack Block Theme.', 'text-domain' ),
+			)
+		);
+	}
 }
+
 
 Core::instance();

--- a/patterns/archive-offset-right.php
+++ b/patterns/archive-offset-right.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Title: Archive - Offset Right
+ * Slug: newspack-block-theme/archive-offset-right
+ * Categories: newspack-block-theme
+ * Description:
+ * Keywords: archives
+ * Block Types: core/query
+ * Template Types: archive
+ *
+ * @package Newspack_Block_Theme
+ */
+
+?>
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","className":"newspack-archive-offset-right","layout":{"type":"constrained"}} -->
+<main class="wp-block-query newspack-archive-offset-right"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"22.7%"} -->
+<div class="wp-block-column" style="flex-basis:22.7%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":""} -->
+<div class="wp-block-column"><!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|60","left":"var:preset|spacing|60"}}}} -->
+<div class="wp-block-columns"><!-- wp:column {"width":"66.66%"} -->
+<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:query-title {"type":"archive","showPrefix":false} /-->
+
+<!-- wp:term-description {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"33.33%"} -->
+<div class="wp-block-column" style="flex-basis:33.33%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:post-template -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|60"}}},"className":"is-style-first-col-to-second"} -->
+<div class="wp-block-columns is-style-first-col-to-second"><!-- wp:column {"width":"31.25%"} -->
+<div class="wp-block-column" style="flex-basis:31.25%"><!-- wp:post-featured-image {"aspectRatio":"3/2"} /--></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":""} -->
+<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:post-terms {"term":"category","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"uppercase"}},"fontSize":"small"} /-->
+
+<!-- wp:post-title {"isLink":true,"fontSize":"large"} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:post-excerpt /-->
+
+<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true} /-->
+
+<!-- wp:post-date {"isLink":true} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:separator {"backgroundColor":"quartary"} -->
+<hr class="wp-block-separator has-text-color has-quartary-color has-alpha-channel-opacity has-quartary-background-color has-background"/>
+<!-- /wp:separator --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:post-template --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous /-->
+
+<!-- wp:query-pagination-numbers /-->
+
+<!-- wp:query-pagination-next /-->
+<!-- /wp:query-pagination --></div>
+<!-- /wp:group --></main>
+<!-- /wp:query -->

--- a/theme.json
+++ b/theme.json
@@ -551,8 +551,7 @@
 					"text": "var( --wp--custom--color--gray-700 )"
 				},
 				"typography": {
-					"fontSize": "1.375rem",
-					"lineHeight": "1.5454"
+					"fontSize": "1.375rem"
 				}
 			}
 		},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR illustrates one of two possible approaches for building out our alternative archive layouts by adding a block pattern for a different archive layout. 

Unlike post types (like posts, pages, and custom), we can't build alternative templates generated pages like archives, search, 404. And unlike Headers and Footer template parts, the more general 'uncategorized' content template parts can't be easily swapped for one another through using the block tools -- you essentially have to delete one and replace it with another. 

Block patterns can be nicely swapped for like-blocks -- for example, it's possible to swap a core-query-based block for a core query baed block pattern really easily with the block tools. 

However, unlike template parts, if block patterns are used for these layouts, we can't make any changes to them once inserted -- we can lock them, but once inserted at least the contents of the pattern will be saved in the site's database, and won't be over-ride-able from the theme. We can do some fancy footwork to lock parts of the theme, but ultimately, it means there will be areas of the template we can't access. 

Similar to overwritten template parts, we can have pubs "roll back" or "refresh" block patterns by inserting them fresh from the block picker. 

It does look like it will be possible to limit patterns to template types in the future ([based on the note here](https://fullsiteediting.com/lessons/introduction-to-block-patterns/#h-templatetypes)); in the meantime, it may make sense to categorize them a little more specifically as we add more (instead of "Newspack Block Theme" as a category, have a "Newspack Block Theme - Archives", "Newspack Block Theme - Search"...). 

### How to test the changes in this Pull Request:

1. Apply this PR and run `npm run build`.
2. Navigate to Site Editor > Templates, and select the 'Archive' template to edit. 
3. Click in the editor (or use the 'List View' in the top-left corner) to select the main Query block:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/9bfd12f8-f990-4a15-8ba7-edf217dbd91c)

4. Click the 'Replace' button in the block toolbar.
5. From the popup that appears, search for 'Archive' and select the 'Archive - Offset Right' pattern (note: we can remove some or all of the core patterns from the library to make finding the theme-based ones easier - there's an issue that touches on that in this repo [here](https://github.com/Automattic/newspack-block-theme/pull/48)). 

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/82b86b7a-8b08-46f8-8a59-f8885733a76b)

6. Click 'Save'.
7. View a standard archive on the site, and note its appearance changed. This pattern is based off of this mockup:

![archive - offset right](https://github.com/Automattic/newspack-block-theme/assets/177561/eaa96d17-25c0-4131-b6b8-e4fcfa2196c7)

#### Questions
1. How was this experience? How does it compare to #57?
2. Any concerns about using block patterns, and not being able to edit these once inserted?
3. Any other thoughts/ideas/suggestions?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
