### PR TITLE
fix: make archive spacing more consistent

### DIFF
--- a/src/scss/_gutenberg-shim.scss
+++ b/src/scss/_gutenberg-shim.scss
@@ -57,9 +57,17 @@ figcaption a {
  * The underlying issue is that the author bio block lacks paragraphs,
  * so its spacing and the term description spacing differ.
  */
- .wp-block-term-description p:first-child {
- 	margin-top: 0;
- }
+.wp-block-term-description {
+	p {
+		&:first-child {
+			margin-top: 0;
+		}
+
+		&:last-child {
+			margin-bottom: 0;
+		}
+	}
+}
 
 /*
  * Search styles

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,18 +1,14 @@
 <!-- wp:template-part {"slug":"header","theme":"newspack-block-theme","tagName":"header"} /-->
 
 <!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","layout":{"type":"constrained"}} -->
-<main class="wp-block-query"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:query-title {"type":"archive","showPrefix":false} /-->
+<main class="wp-block-query"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:query-title {"type":"archive","showPrefix":false} /-->
 
 <!-- wp:term-description {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:post-template -->
-<!-- wp:columns {"className":"is-style-first-col-to-second"} -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|50"}}},"className":"is-style-first-col-to-second"} -->
 <div class="wp-block-columns is-style-first-col-to-second"><!-- wp:column {"width":"150px"} -->
 <div class="wp-block-column" style="flex-basis:150px"><!-- wp:post-featured-image {"aspectRatio":"3/2"} /--></div>
 <!-- /wp:column -->

--- a/templates/author.html
+++ b/templates/author.html
@@ -1,18 +1,14 @@
 <!-- wp:template-part {"slug":"header","theme":"newspack-block-theme","tagName":"header"} /-->
 
 <!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","layout":{"type":"constrained"}} -->
-<main class="wp-block-query"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|60"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--60)"><!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group"><!-- wp:query-title {"type":"archive","showPrefix":false} /-->
+<main class="wp-block-query"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|70"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--70)"><!-- wp:query-title {"type":"archive","showPrefix":false} /-->
 
 <!-- wp:post-author-biography {"fontSize":"large"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group --></div>
 <!-- /wp:group -->
 
 <!-- wp:post-template -->
-<!-- wp:columns {"className":"is-style-first-col-to-second"} -->
+<!-- wp:columns {"style":{"spacing":{"blockGap":{"top":"var:preset|spacing|30","left":"var:preset|spacing|50"}}},"className":"is-style-first-col-to-second"} -->
 <div class="wp-block-columns is-style-first-col-to-second"><!-- wp:column {"width":"150px"} -->
 <div class="wp-block-column" style="flex-basis:150px"><!-- wp:post-featured-image {"aspectRatio":"3/2"} /--></div>
 <!-- /wp:column -->

--- a/theme.json
+++ b/theme.json
@@ -551,7 +551,8 @@
 					"text": "var( --wp--custom--color--gray-700 )"
 				},
 				"typography": {
-					"fontSize": "1.375rem"
+					"fontSize": "1.375rem",
+					"lineHeight": "1.5454"
 				}
 			}
 		},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR improves the spacing consistency between the archive.html and author.html templates, improves the spacing in the columns blocks used in these templates, and gives the term-description block the correct line height.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
