### PR TITLE
fix: make navigation block's overlayMenu default never

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -115,6 +115,9 @@ final class Core {
 			$metadata['attributes']['placeholder']['default']    = esc_html__( 'Search...', 'newspack-block-theme' );
 			$metadata['attributes']['showLabel']['default']      = false;
 		}
+		if ( $metadata[ 'name' ] == 'core/navigation' ) {
+			$metadata['attributes']['overlayMenu']['default'] = 'never';
+		}
 		return $metadata;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similar to #44, this PR changes the default settings for the Navigation block. In this case, it changes the "OverlayMenu" (essentially the mobile hamburger) option to 'never' by default. This matches with how the menu will be used in our template parts for now.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Add a navigation block to the editor; confirm that the Overlay Menu option (under the Settings tab) defaults to 'Off':

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/842e92d7-4f54-4785-bf10-9597e483d6ee)

3. Confirm that this is the case on the front end (no amount of changing the screen size will cause your navigation block to turn into a hamburger).
4. Confirm that you can still change the option and that it will be changed on the front-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
