### PR TITLE
fix: correct single post space; add tag styles

### DIFF
--- a/parts/comments.html
+++ b/parts/comments.html
@@ -1,5 +1,5 @@
-<!-- wp:comments {"className":"wp-block-comments-query-loop"} -->
-<div class="wp-block-comments wp-block-comments-query-loop"><!-- wp:comments-title {"level":3} /-->
+<!-- wp:comments {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}},"className":"wp-block-comments-query-loop"} -->
+<div class="wp-block-comments wp-block-comments-query-loop" style="margin-top:var(--wp--preset--spacing--70)"><!-- wp:comments-title {"level":3} /-->
 
 <!-- wp:comment-template {"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"var:preset|spacing|50","left":"0"}}}} -->
 <!-- wp:group -->
@@ -33,9 +33,5 @@
 <!-- wp:comments-pagination-next /-->
 <!-- /wp:comments-pagination -->
 
-<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
-<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer -->
-
-<!-- wp:post-comments-form /--></div>
+<!-- wp:post-comments-form {"style":{"spacing":{"margin":{"top":"var:preset|spacing|70"}}}} /--></div>
 <!-- /wp:comments -->

--- a/parts/post-footer.html
+++ b/parts/post-footer.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:post-terms {"term":"post_tag","style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"small"} /--></div>
+<div class="wp-block-group"><!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}},"layout":{"type":"flex"}} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30)"><!-- wp:post-terms {"term":"post_tag","style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"small"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/parts/post-footer.html
+++ b/parts/post-footer.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex"}} -->
-<div class="wp-block-group"><!-- wp:post-terms {"term":"post_tag","fontSize":"small"} /--></div>
+<div class="wp-block-group"><!-- wp:post-terms {"term":"post_tag","style":{"layout":{"selfStretch":"fill","flexSize":null}},"fontSize":"small"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -7,5 +7,6 @@
 @import url( './_post-author-name.scss' );
 @import url( './_post-comments.scss' );
 @import url( './_post-carousel.scss' );
+@import url( './_post-terms.scss' );
 @import url( './_pullquote.scss' );
 @import url( './_search.scss' );

--- a/src/scss/blocks/_post-terms.scss
+++ b/src/scss/blocks/_post-terms.scss
@@ -1,0 +1,18 @@
+.wp-block-post-terms {
+	&.taxonomy-post_tag {
+		border-top: 1px solid var( --wp--custom--color--gray-200 );
+		padding: var(--wp--preset--spacing--30) 0;
+
+		a {
+			border: 1px solid var( --wp--custom--color--gray-100 );
+			border-radius: var( --wp--custom--border--radius );
+			display: inline-block;
+			margin-right: 0.25rem;
+			padding: 0.1875rem 0.5625rem;
+		}
+
+		.wp-block-post-terms__separator {
+			display: none;
+		}
+	}
+}

--- a/src/scss/blocks/_post-terms.scss
+++ b/src/scss/blocks/_post-terms.scss
@@ -1,8 +1,5 @@
 .wp-block-post-terms {
 	&.taxonomy-post_tag {
-		border-top: 1px solid var( --wp--custom--color--gray-200 );
-		padding: var(--wp--preset--spacing--30) 0;
-
 		a {
 			border: 1px solid var( --wp--custom--color--gray-100 );
 			border-radius: var( --wp--custom--border--radius );

--- a/templates/single.html
+++ b/templates/single.html
@@ -9,17 +9,15 @@
 
 <!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /-->
 
-<!-- wp:template-part {"slug":"post-footer","theme":"newspack-block-theme"} /-->
-
 <!-- wp:spacer {"height":"var:preset|spacing|50"} -->
 <div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:template-part {"slug":"author-bio","theme":"newspack-block-theme"} /-->
+<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:template-part {"slug":"post-footer","theme":"newspack-block-theme","className":"post-footer"} /-->
 
-<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></main>
+<!-- wp:template-part {"slug":"author-bio","theme":"newspack-block-theme","className":"author-bio"} /--></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->

--- a/templates/single/large-image.html
+++ b/templates/single/large-image.html
@@ -15,17 +15,15 @@
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} -->
 <main class="wp-block-group"><!-- wp:post-content {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} /-->
 
-<!-- wp:template-part {"slug":"post-footer","theme":"newspack-block-theme"} /-->
-
 <!-- wp:spacer {"height":"var:preset|spacing|50"} -->
 <div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:template-part {"slug":"author-bio","theme":"newspack-block-theme"} /-->
+<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:template-part {"slug":"post-footer","theme":"newspack-block-theme","className":"post-footer"} /-->
 
-<!-- wp:spacer {"height":"var:preset|spacing|50"} -->
-<div style="height:var(--wp--preset--spacing--50)" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></main>
+<!-- wp:template-part {"slug":"author-bio","theme":"newspack-block-theme","className":"author-bio"} /--></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR moves some of the vertical spacing in the post footer from spacer blocks to margins. This way, if there aren't tags, or if there isn't a comment form, we don't end up with a bunch of excess spacing. 

It also adds styles to the tags that were initially missed; this was mostly done through CSS. Unfortunately, a couple elements (the 'Tagged' prefix, the top border) won't disappear if the tags aren't populated 😕 We can _technically_ add them with CSS, but I've omitted for now just to avoid adding things we can't remove by editing the blocks. 

I've added a note to myself to follow up on that! 

Tag mockup:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/4877e76c-103e-43f8-8caf-f92e8c3b06ab)

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
