### PR TITLE
fix: add bottom space to post title in editor

### DIFF
--- a/src/scss/_gutenberg-shim.scss
+++ b/src/scss/_gutenberg-shim.scss
@@ -111,3 +111,16 @@ input[type='color'],
 textarea {
 	border-radius: var( --wp--custom--border--radius );
 }
+
+
+/*
+ * Editor styles
+ *
+ * Fix spacing between title and editor content.
+ * In other themes, this comes from the spacing around the block, but we're using flex and gap.
+ */
+ .edit-post-visual-editor {
+	&__post-title-wrapper {
+		margin-bottom: var(--wp--preset--spacing--40);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a bottom margin to the post title field in the editor. I noticed in our theme it was really close to the content, which seemed strange. 

Looking at Twenty Twenty Three, I think the issue might be partially structural: in our theme, the post and page header is in its own group (which helps with vertical spacing), and for posts, the post title in spaced away from the byline using flexbox's gap, not a margin. In Twenty Twenty Three, the post title has a top and bottom margin, which is also applied in the editor so the title and content aren't as close together.

This fix feels a little hacky, but I think it's better than trying to change how the front-end is set up so the pieces look okay in the backend, especially since the reason we have the problem is that the structure of the blocks is different on the front-end than it appears in the single post editor. 

Edited to add: added to the gutenberg-shim styles since this seems like something that might have a better more official work-around.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
