### PR TITLE
fix: remove link from post date archive

### DIFF
--- a/templates/archive.html
+++ b/templates/archive.html
@@ -25,7 +25,7 @@
     <!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
     <div class="wp-block-group"><!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"fontSize":"x-small"} /-->
     
-    <!-- wp:post-date {"isLink":true,"fontSize":"x-small"} /--></div>
+    <!-- wp:post-date {"fontSize":"x-small"} /--></div>
     <!-- /wp:group --></div>
     <!-- /wp:column --></div>
     <!-- /wp:columns -->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Super small PR that just removes the `isLink: true` from the post-date block in the Archive page

### How to test the changes in this Pull Request:

1. Open archive page in editor
2. Check post-date (the isLink toggle should be on)
3. Switch to this branch
4. Refresh and check again (the toggle should be off)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
