### PR TITLE
feat: add 2x-small font size

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -96,6 +96,12 @@
 			"fontSizes": [
 				{
 					"fluid": false,
+					"name": "2X-Small",
+					"size": "0.75rem",
+					"slug": "xx-small"
+				},
+				{
+					"fluid": false,
 					"name": "X-Small",
 					"size": "0.875rem",
 					"slug": "x-small"
@@ -163,6 +169,7 @@
 				"mobile-menu-overlay": "rgba( 0, 0, 0, 0.5 )"
 			},
 			"line-height": {
+				"xx-small": "1.3333333333",
 				"x-small": "1.7142857143",
 				"small": "1.5",
 				"medium": "1.6",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

font-size: 0.75rem (12px)
line-height: 1.33 (16px)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Check if you see the new font size in text settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
