### PR TITLE
feat: update button style

### DIFF
--- a/src/scss/blocks/_button.scss
+++ b/src/scss/blocks/_button.scss
@@ -1,20 +1,29 @@
-.has-x-small-font-size {
+.is-style-padding-small {
 	.wp-block-button {
 		&__link {
-			padding: 0.5rem 1.5rem;
+			padding: 0.75rem 1.5rem;
 		}
-	}
-
-	.wp-block-button,
-	&.wp-block-button {
-		font-size: var(--wp--preset--font-size--small) !important;
-		line-height: var(--wp--custom--line-height--small);
 	}
 
 	.is-style-outline,
 	&.is-style-outline {
 		.wp-block-button__link {
-			padding: calc(0.5rem - 1.5px) calc(1.5rem - 1.5px) !important;
+			padding: calc(0.75rem - 1.5px) calc(1.5rem - 1.5px) !important;
+		}
+	}
+}
+
+.is-style-padding-x-small {
+	.wp-block-button {
+		&__link {
+			padding: 0.5rem 1rem;
+		}
+	}
+
+	.is-style-outline,
+	&.is-style-outline {
+		.wp-block-button__link {
+			padding: calc(0.5rem - 1.5px) calc(1rem - 1.5px) !important;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I removed the styling based on the font-size introduced in #91.

Upon further consideration, it didn't make sense to associate the font-size with the padding and restrict the font-size to small.

Instead, I am introducing 2 new (hidden) style variations. I don't believe we need to expose these variations in the editor since they should only be used for UI purposes. Additionally, they can be achieved through the padding settings in the editor, except for the outline style where you cannot subtract the border. This is the main reason why I created these classes.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add a bunch of buttons (with different size) to a page
3. In some of them, add a custom css class: `is-style-padding-small` or `is-style-padding-x-small`
4. Check if their padding is affected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
