### PR TITLE
feat: add underline to navigation styles

### DIFF
--- a/src/scss/block-styles/_navigation-styles.scss
+++ b/src/scss/block-styles/_navigation-styles.scss
@@ -66,10 +66,15 @@
 	}
 
 	a {
-		text-decoration: none;
+		text-decoration-color: transparent;
+		text-decoration-thickness: 0.1875em !important;
+		text-underline-offset: 0.375em;
+		transition: all 125ms linear;
+		transition-delay: 100ms;
 
 		&:not(.wp-element-button):hover {
 			text-decoration: underline;
+			text-decoration-color: currentcolor;
 		}
 	}
 }

--- a/src/scss/blocks/_search.scss
+++ b/src/scss/blocks/_search.scss
@@ -30,6 +30,7 @@
 
 		.wp-block-search__inside-wrapper {
 			background-color: var(--wp--preset--color--base);
+			border-color: var(--wp--preset--color--tertiary);
 			border-radius: var(--wp--custom--border--radius-medium);
 			box-sizing: border-box;
 		}

--- a/theme.json
+++ b/theme.json
@@ -368,7 +368,7 @@
 				"elements": {
 					"link": {
 						"typography": {
-							"textDecoration": "none"
+							"textDecoration": "underline"
 						}
 					}
 				},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Links in the navigation block are now using an underline, transparent by default, then coloured on hover. This allowed for a smooth transition when hovering.

I also increased the thickness of the line.

### How to test the changes in this Pull Request:

1. Check a navigation block on the front-end
2. Switch to this branch
3. Repeat 1

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
