### PR TITLE
feat: add support for co-author plus blocks

### DIFF
--- a/patterns/post-header.php
+++ b/patterns/post-header.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Title: Post Header
+ * Slug: newspack-block-theme/post-header
+ * Categories: newspack-block-theme
+ *
+ * @package Newspack_Block_Theme
+ */
+
+?>
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group">
+<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:post-terms {"term":"category","style":{"typography":{"fontStyle":"normal","fontWeight":"700","textTransform":"uppercase"}},"fontSize":"medium"} /-->
+
+<!-- wp:post-title {"level":1} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:post-excerpt {"fontSize":"large"} /-->
+
+<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group">
+
+<?php if ( class_exists( 'CoAuthors_Guest_Authors' ) ) : ?>
+<!-- wp:co-authors-plus/coauthors -->
+<div class="wp-block-co-authors-plus-coauthors">
+<!-- wp:co-authors-plus/name /--></div>
+<!-- /wp:co-authors-plus/coauthors -->
+<?php else : ?>
+<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":false} /-->
+<?php endif; ?>
+
+<!-- wp:post-date {"format":"F j, Y, g:i a","isLink":false} /--></div>
+<!-- /wp:group -->
+</div>
+<!-- /wp:group -->

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -94,3 +94,15 @@
 		}
 	}
 }
+
+@mixin cap-avatar( $width, $amount: 5 ) {
+	@for $i from 1 through $amount {
+		&:has( .wp-block-co-authors-plus-coauthor:nth-of-type(#{$i}) ) {
+			padding-left: calc( #{$i} * #{$width} - #{$i - 1} * var(--wp--preset--spacing--20 ) );
+
+			.wp-block-co-authors-plus-coauthor:nth-of-type(#{$i}) .wp-block-co-authors-plus-avatar {
+				margin-left: calc( #{$i - 1} * #{$width} - #{$i - 1} * var(--wp--preset--spacing--20 ) );
+			}
+		}
+	}
+}

--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -1,4 +1,5 @@
 @import url('./_button.scss');
+@import url('./_co-authors-plus.scss');
 @import url('./_columns.scss');
 @import url('./_homepage-articles.scss');
 @import url('./_navigation.scss');

--- a/src/scss/blocks/_co-authors-plus.scss
+++ b/src/scss/blocks/_co-authors-plus.scss
@@ -1,0 +1,28 @@
+@use '../mixins';
+
+.wp-block-co-authors-plus-coauthors {
+
+    &.wp-block-coauthors-is-layout-flow {
+        position: relative;
+
+        &:has(.wp-block-co-authors-plus-avatar) {
+            padding-left: calc( 24px + var(--wp--preset--spacing--20) );
+
+            .wp-block-co-authors-plus-coauthors__prefix {
+                margin-left: var(--wp--preset--spacing--20);
+            }
+
+            @include mixins.cap-avatar( $width: 24px );
+        }
+    
+        .wp-block-co-authors-plus-avatar {
+            left: 0;
+            position: absolute;
+            top: 0;
+    
+            img {
+                display: block;
+            }
+        }
+    }
+}

--- a/src/scss/blocks/_homepage-articles.scss
+++ b/src/scss/blocks/_homepage-articles.scss
@@ -309,11 +309,11 @@
 					@include mixins.wpnbha-avatar( $width: 2.5rem );
 
 					&:not(:has(.entry-date)) {
-						@include mixins.wpnbha-avatar( $width: 2rem );
+						@include mixins.wpnbha-avatar( $width: 1.5rem );
 	
 						.avatar {
-							height: 2rem;
-							width: 2rem;
+							height: 1.5rem;
+							width: 1.5rem;
 						}
 	
 						.byline {

--- a/templates/single.html
+++ b/templates/single.html
@@ -3,7 +3,7 @@
 <!-- wp:pattern {"slug":"newspack-block-theme/post-header"} /-->
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80"}}}} /-->
+<main class="wp-block-group"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80","top":"var:preset|spacing|80"}}}} /-->
 
 <!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,11 +1,9 @@
 <!-- wp:template-part {"slug":"header","theme":"newspack-block-theme","tagName":"header"} /-->
 
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:template-part {"slug":"post-header","theme":"newspack-block-theme","area":"uncategorized"} /--></div>
-<!-- /wp:group -->
+<!-- wp:pattern {"slug":"newspack-block-theme/post-header"} /-->
 
 <!-- wp:group {"tagName":"main","lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} -->
-<main class="wp-block-group"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|60"}}}} /-->
+<main class="wp-block-group"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80"}}}} /-->
 
 <!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 

--- a/templates/single/wide-image.html
+++ b/templates/single/wide-image.html
@@ -2,7 +2,7 @@
 
 <!-- wp:pattern {"slug":"newspack-block-theme/post-header"} /-->
 
-<!-- wp:group {"lock":{"move":false,"remove":true},"layout":{"type":"constrained","wideSize":"960px"}} -->
+<!-- wp:group {"lock":{"move":false,"remove":true},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:post-featured-image {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|80","top":"var:preset|spacing|80"}}}} /--></div>
 <!-- /wp:group -->
 

--- a/theme.json
+++ b/theme.json
@@ -238,6 +238,20 @@
 	},
 	"styles": {
 		"blocks": {
+			"co-authors-plus/avatar": {
+				"border": {
+					"radius": "50%"
+				}
+			},
+			"co-authors-plus/coauthors": {
+				"color": {
+					"text": "var( --wp--preset--color--contrast-3 )"
+				},
+				"typography": {
+					"fontSize": "var( --wp--preset--font-size--x-small )",
+					"lineHeight": "var( --wp--custom--line-height--x-small )"
+				}
+			},
 			"core/button": {
 				"spacing": {
 					"padding": {
@@ -810,6 +824,13 @@
 				"post"
 			],
 			"title": "Single - Large Image"
+		},
+		{
+			"name": "single/wide-image",
+			"postTypes": [
+				"post"
+			],
+			"title": "Single - Wide Image"
 		}
 	],
 	"templateParts": [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I'm using a pattern with PHP so if CAP is active, the post-header uses the CAP blocks, if not, we use Core's author block.
I've also updated the other single post templates.

### How to test the changes in this Pull Request:

1. Make sure a post has multiple authors and you have CAP active
2. Check your post, you should only see 1 author
3. Switch to this branch and recheck your post
4. Disable CAP and recheck your post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
