### PR TITLE
fix: correct annoying search preview issue

### DIFF
--- a/src/scss/_search-overlay.scss
+++ b/src/scss/_search-overlay.scss
@@ -10,7 +10,7 @@
 	opacity: 0;
 	overflow: auto;
 	padding: var(--wp--preset--spacing--30);
-	position: fixed;
+	position: fixed !important; // !important to override some styles in the editor.
 	transition: opacity 0.125s;
 	width: 100%;
 	z-index: sass-utils.$zindex-overlay-menu;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes an editor preview issue with the search overlay. The `fixed` position coming from the theme was getting overridden by more specific editor styles.

### How to test the changes in this Pull Request:

1. Edit one of the full-page templates; note how dang tall the header is:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/28011d72-d6f4-4343-a8a9-7d5c5d1a1c14)

2. Apply this PR and run `npm run build`.
3. Confirm the header now looks closer to the front-end in the editor:

![image](https://github.com/Automattic/newspack-block-theme/assets/177561/4be59a6e-ac7f-4268-a742-aa9efca60b0b)

4. View the front end and test the search to confirm it still works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
