### PR TITLE
feat: add specific styles for media & text block

### DIFF
--- a/src/scss/block-patterns/_block-patterns.scss
+++ b/src/scss/block-patterns/_block-patterns.scss
@@ -1,0 +1,24 @@
+@use '../sass-utils';
+
+.newspack-pattern {
+    &.subscribe {
+        &__style-squeeze {
+            .wp-block-media-text__content {
+                padding: 0;
+                grid-column: span 2;
+
+                @include sass-utils.media(medium) {
+                    grid-column: auto;
+                }
+            }
+
+            .wp-block-media-text__media {
+                display: none;
+
+                @include sass-utils.media(medium) {
+                    display: block;
+                }
+            }
+        }
+    }
+}

--- a/src/scss/block-patterns/_block-patterns.scss
+++ b/src/scss/block-patterns/_block-patterns.scss
@@ -1,6 +1,7 @@
 @use '../sass-utils';
 
 .newspack-pattern {
+    &.donations,
     &.subscribe {
         &__style-squeeze {
             .wp-block-media-text__content {

--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -2,6 +2,7 @@
 @import url('./_co-authors-plus.scss');
 @import url('./_columns.scss');
 @import url('./_homepage-articles.scss');
+@import url('./_media-text.scss');
 @import url('./_navigation.scss');
 @import url('./_paragraph.scss');
 @import url('./_pagination.scss');

--- a/src/scss/blocks/_media-text.scss
+++ b/src/scss/blocks/_media-text.scss
@@ -1,0 +1,18 @@
+.wp-block-media-text {
+    & &__content {
+        padding: var( --wp--preset--spacing--80 );
+
+        > * {
+            margin-bottom: var( --wp--preset--spacing--50 );
+            margin-top: var( --wp--preset--spacing--50 );
+
+            &:first-child {
+                margin-top: 0;
+            }
+
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -4,6 +4,7 @@
 @import url('./_forms.scss');
 @import url('./_gutenberg-shim.scss');
 @import url('./blocks/_blocks.scss');
+@import url('./block-patterns/_block-patterns.scss');
 @import url('./block-styles/_block-styles.scss');
 @import url('./_header.scss');
 @import url('./_comments-overlay.scss');


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds better padding/gap to the Media & Text block. It also adds a bit of custom CSS to the Pattern Subscribe 7

### How to test the changes in this Pull Request:

1. Add a Media & Text block to a page
2. Check front-end
3. Switch to this branch
4. Re check
5. Add Pattern Subscribe 7 (via https://github.com/Automattic/newspack-blocks/pull/1745)
6. Check if css is applied properly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
