### PR TITLE
feat: add support for table block

### DIFF
--- a/src/scss/blocks/_blocks.scss
+++ b/src/scss/blocks/_blocks.scss
@@ -15,4 +15,5 @@
 @import url('./_quote.scss');
 @import url('./_sharing-buttons.scss');
 @import url('./_search.scss');
+@import url('./_table.scss');
 @import url('./_top-posts.scss');

--- a/src/scss/blocks/_table.scss
+++ b/src/scss/blocks/_table.scss
@@ -1,0 +1,39 @@
+.wp-block-table {
+	thead,
+	tfoot {
+		border-width: 0.25rem;
+	}
+
+	td,
+	th {
+		padding: var( --wp--preset--spacing--20 );
+	}
+
+	table {
+		&[style*='border-width'] {
+			thead,
+			tfoot {
+				border-width: inherit;
+			}
+		}
+
+		&:not(.has-border-color) {
+			thead,
+			tfoot,
+			td,
+			th {
+				border-color: var( --wp--preset--color--base-3 );
+			}
+		}
+	}
+
+	&.is-style-stripes {
+		border-bottom: 0;
+
+		tbody {
+			tr:nth-child( odd ) {
+				background-color: var( --wp--preset--color--base-2 );
+			}
+		}
+	}
+}

--- a/src/scss/blocks/_table.scss
+++ b/src/scss/blocks/_table.scss
@@ -36,4 +36,17 @@
 			}
 		}
 	}
+
+	&[style*='font-size'],
+	&[class*='font-size'] {
+		table {
+			font-size: inherit;
+		}
+	}
+
+	&[style*='line-height'] {
+		table {
+			line-height: inherit;
+		}
+	}
 }

--- a/theme.json
+++ b/theme.json
@@ -492,6 +492,7 @@
 					"blockGap": "var( --wp--preset--spacing--50 )"
 				},
 				"typography": {
+					"fontFamily": "var( --wp--preset--font-family--system-font )",
 					"fontSize": "var( --wp--preset--font-size--small )",
 					"fontWeight": "600",
 					"lineHeight": "var( --wp--custom--line-height--small )"
@@ -852,8 +853,15 @@
 					"text": "var( --wp--preset--color--contrast-3 )"
 				},
 				"typography": {
+					"fontFamily": "var( --wp--preset--font-family--system-font )",
 					"fontSize": "var( --wp--preset--font-size--x-small )",
-					"lineHeight": "var( --wp--custom--line-height--x-small )"
+					"fontStyle": "normal",
+					"fontWeight": "400",
+					"letterSpacing": "0",
+					"lineHeight": "var( --wp--custom--line-height--x-small )",
+					"textDecoration": "none",
+					"textTransform": "none"
+
 				}
 			},
 			"h1": {

--- a/theme.json
+++ b/theme.json
@@ -754,6 +754,17 @@
 					"lineHeight": "var( --wp--custom--line-height--large )"
 				}
 			},
+			"core/table": {
+				"border": {
+					"color": "var( --wp--preset--color--base-3 )",
+					"style": "solid",
+					"width": "1px"
+				},
+				"typography": {
+					"fontSize": "var( --wp--preset--font-size--small )",
+					"lineHeight": "var( --wp--custom--line-height--small )"
+				}
+			},
 			"core/term-description": {
 				"typography": {
 					"fontSize": "var( --wp--preset--font-size--large )",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds basic styles to the Table block. By default the borders are using #dddddd and the font-size has been reduced to small.

### How to test the changes in this Pull Request:

1. Add a Table block to a page
2. Preview
3. Switch to this branch
4. Preview again
5. Play with the settings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
