### PR TITLE
feat(column-block): add rounded block style

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -43,6 +43,7 @@ final class Core {
 		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'editor_scripts' ] );
 		\add_filter( 'block_type_metadata', [ __CLASS__, 'block_variations' ] );
 		\add_action( 'init', [ __CLASS__, 'block_pattern_categories' ] );
+		\add_action( 'init', [ __CLASS__, 'register_block_styles' ] );
 	}
 
 	/**
@@ -145,6 +146,21 @@ final class Core {
 			array(
 				'label'       => __( 'Newspack Theme - Post Meta', 'newspack-block-theme' ),
 				'description' => __( 'Patterns bundled with the Newspack Block Theme, specifically built for the post meta.', 'newspack-block-theme' ),
+			)
+		);
+	}
+
+	/**
+	 * Register new block styles.
+	 *
+	 * @since Newspack Block Theme 1.0
+	 */
+	public static function register_block_styles() {
+		register_block_style(
+			'core/column',
+			array(
+				'name'  => 'rounded',
+				'label' => __( 'Rounded', 'newspack-block-theme' ),
 			)
 		);
 	}

--- a/src/scss/block-styles/_block-styles.scss
+++ b/src/scss/block-styles/_block-styles.scss
@@ -1,2 +1,3 @@
+@import url('./_column-styles.scss');
 @import url('./_navigation-styles.scss');
 @import url('./_separator-styles.scss');

--- a/src/scss/block-styles/_column-styles.scss
+++ b/src/scss/block-styles/_column-styles.scss
@@ -1,0 +1,5 @@
+.wp-block-column {
+	&.is-style-rounded {
+		border-radius: var( --wp--custom--border--radius-medium );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR introduces a new style variation to the Column block, named "Rounded". Essentially, it adds a border-radius to the Column (the block currently [doesn't support Border Radius setting](https://github.com/WordPress/gutenberg/issues/41345)).

![Screenshot 2024-06-05 at 12 08 04@2x](https://github.com/Automattic/newspack-block-theme/assets/177929/beaac798-aed5-4e27-96a5-26ad9793c65e)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add a Columns block
3. Select the Column inside, see if you can switch the style to "Rounded"
4. Add a background colour or border to the Column to actually see the result.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
