### PR TITLE
feat: add negative margin to last block in entry-content when fullwidth and background

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -84,15 +84,13 @@ ul, ol {
 // Content
 .post-image {
 	&:empty {
-		&::before {
-			background: var( --wp--preset--color--base-3 );
-			content: "";
-			display: block;
-			height: 1px;
-			width: 100%;
-			margin: 0 auto;
-			max-width: var( --wp--style--global--wide-size );
-		}
+		display: none;
+	}
+}
+
+.entry-content {
+	> :last-child:is( .alignfull ):is( .has-background ) {
+		margin-bottom: calc( -1 * var( --wp--preset--spacing--80 ) ) !important;
 	}
 }
 

--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -48,7 +48,7 @@ input[type='radio'] {
 	@include mixins.radio;
 }
 
-button,
+button:not( .components-button ),
 input[type='submit'] {
 	background: var( --wp--preset--color--accent );
 	border: 0;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
