### PR TITLE
fix: exclude styles for navigation submenu toggle

### DIFF
--- a/src/scss/_forms.scss
+++ b/src/scss/_forms.scss
@@ -48,7 +48,7 @@ input[type='radio'] {
 	@include mixins.radio;
 }
 
-button:not( .components-button ):not( .newspack-ui__button ),
+button:not( .components-button ):not( .newspack-ui__button ):not( .wp-block-navigation-submenu__toggle ),
 input[type='submit']:not( .newspack-ui__button ) {
 	background: var( --wp--preset--color--accent );
 	border: 0;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
