### PR TITLE
feat(footer): update template part to use desktop and mobile parts

### DIFF
--- a/parts/footer-desktop.html
+++ b/parts/footer-desktop.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"newspack-block-theme/footer-desktop-style-1"} /-->

--- a/parts/footer-mobile.html
+++ b/parts/footer-mobile.html
@@ -1,0 +1,1 @@
+<!-- wp:pattern {"slug":"newspack-block-theme/footer-mobile-style-1"} /-->

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,1 +1,3 @@
-<!-- wp:pattern {"slug":"newspack-block-theme/footer-style-1"} /-->
+<!-- wp:template-part {"slug":"footer-desktop","theme":"newspack-block-theme","tagName":"footer","lock":{"move":true,"remove":true},"className":"footer-desktop desktop-only"} /-->
+
+<!-- wp:template-part {"slug":"footer-mobile","theme":"newspack-block-theme","tagName":"footer","lock":{"move":true,"remove":true},"className":"footer-mobile mobile-only"} /-->

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,3 +1,3 @@
-<!-- wp:template-part {"slug":"footer-desktop","theme":"newspack-block-theme","tagName":"footer","lock":{"move":true,"remove":true},"className":"footer-desktop desktop-only"} /-->
+<!-- wp:template-part {"slug":"footer-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"footer-desktop desktop-only"} /-->
 
-<!-- wp:template-part {"slug":"footer-mobile","theme":"newspack-block-theme","tagName":"footer","lock":{"move":true,"remove":true},"className":"footer-mobile mobile-only"} /-->
+<!-- wp:template-part {"slug":"footer-mobile","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"footer-mobile mobile-only"} /-->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,3 +1,3 @@
-<!-- wp:template-part {"slug":"header-desktop","theme":"newspack-block-theme","tagName":"header","lock":{"move":true,"remove":true},"className":"header-desktop desktop-only"} /-->
+<!-- wp:template-part {"slug":"header-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"header-desktop desktop-only"} /-->
 
-<!-- wp:template-part {"slug":"header-mobile","theme":"newspack-block-theme","tagName":"header","lock":{"move":true,"remove":true},"className":"header-mobile mobile-only"} /-->
+<!-- wp:template-part {"slug":"header-mobile","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"header-mobile mobile-only"} /-->

--- a/patterns/footer-desktop-style-1.php
+++ b/patterns/footer-desktop-style-1.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Footer - Style 1
- * Slug: newspack-block-theme/footer-style-1
+ * Title: Footer (Desktop) - Style 1
+ * Slug: newspack-block-theme/footer-desktop-style-1
  * Inserter: no
  * Block Types: core/template-part/footer
  *

--- a/patterns/footer-desktop-style-2.php
+++ b/patterns/footer-desktop-style-2.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Footer - Style 2
- * Slug: newspack-block-theme/footer-style-2
+ * Title: Footer (Desktop) - Style 2
+ * Slug: newspack-block-theme/footer-desktop-style-2
  * Inserter: no
  * Block Types: core/template-part/footer
  *

--- a/patterns/footer-desktop-style-3.php
+++ b/patterns/footer-desktop-style-3.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Footer - Style 3
- * Slug: newspack-block-theme/footer-style-3
+ * Title: Footer (Desktop) - Style 3
+ * Slug: newspack-block-theme/footer-desktop-style-3
  * Inserter: no
  * Block Types: core/template-part/footer
  *

--- a/patterns/footer-desktop-style-4.php
+++ b/patterns/footer-desktop-style-4.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Footer - Style 4
- * Slug: newspack-block-theme/footer-style-4
+ * Title: Footer (Desktop) - Style 4
+ * Slug: newspack-block-theme/footer-desktop-style-4
  * Inserter: no
  * Block Types: core/template-part/footer
  *

--- a/patterns/footer-desktop-style-5.php
+++ b/patterns/footer-desktop-style-5.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: Footer - Style 5
- * Slug: newspack-block-theme/footer-style-5
+ * Title: Footer (Desktop) - Style 5
+ * Slug: newspack-block-theme/footer-desktop-style-5
  * Inserter: no
  * Block Types: core/template-part/footer
  *

--- a/patterns/footer-mobile-style-1.php
+++ b/patterns/footer-mobile-style-1.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Title: Footer (Mobile) - Style 1
+ * Slug: newspack-block-theme/footer-mobile-style-1
+ * Viewport Width: 632
+ * Inserter: no
+ * Block Types: core/template-part/footer
+ *
+ * @package Newspack_Block_Theme
+ */
+
+?>
+<!-- wp:group {"lock":{"move":true,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Footer', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"contrast","textColor":"base","className":"is-footer","layout":{"type":"constrained"}} -->
+<div class="wp-block-group is-footer has-base-color has-contrast-background-color has-text-color has-background has-link-color" style="margin-top:var(--wp--preset--spacing--80)">
+
+	<!-- wp:group {"lock":{"move":true,"remove":true},"align":"wide","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"default"}} -->
+	<div class="wp-block-group alignwide">
+
+		<!-- wp:group {"lock":{"move":true,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+			<!-- wp:site-title {"level":0,"fontSize":"large"} /-->
+
+			<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Description', 'newspack-block-theme' ); ?>"},"layout":{"type":"constrained","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+				<!-- wp:paragraph {"fontSize":"large"} -->
+				<p class="has-large-font-size"><?php esc_html_e( 'Our online newspaper delivers the latest news and insightful analysis. Our experienced journalists ensure accurate and impartial reporting. Stay informed with our engaging and informative articles.', 'newspack-block-theme' ); ?></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+
+			<!-- wp:navigation {"className":"is-style-flatten","style":{"typography":{"fontStyle":"normal","fontWeight":"600"},"spacing":{"blockGap":"var:preset|spacing|30"}},"fontSize":"x-small","layout":{"type":"flex","flexWrap":"wrap"}} /-->
+
+			<!-- wp:social-links {"iconColor":"base","iconColorValue":"#ffffff","iconBackgroundColor":"contrast-2","className":"has-icon-background-color"} -->
+			<ul class="wp-block-social-links has-icon-color has-icon-background-color">
+				<!-- wp:social-link {"url":"#","service":"facebook"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"instagram"} /-->
+
+				<!-- wp:social-link {"url":"#","service":"x"} /-->
+			</ul>
+			<!-- /wp:social-links -->
+		</div>
+		<!-- /wp:group -->
+
+		<!-- wp:group {"lock":{"move":true,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Credits', 'newspack-block-theme' ); ?>"},"className":"is-credits","style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-group is-credits">
+			<!-- wp:separator {"lock":{"move":true,"remove":true},"className":"is-style-wide","backgroundColor":"contrast-2"} -->
+			<hr class="wp-block-separator has-text-color has-contrast-2-color has-alpha-channel-opacity has-contrast-2-background-color has-background is-style-wide"/>
+			<!-- /wp:separator -->
+
+			<!-- wp:group {"lock":{"move":false,"remove":true},"style":{"spacing":{"blockGap":"var:preset|spacing|20","padding":{"bottom":"var:preset|spacing|30"}}},"fontSize":"x-small","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+			<div class="wp-block-group has-x-small-font-size" style="padding-bottom:var(--wp--preset--spacing--30)">
+				<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Copyright', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"0.25em"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
+				<div class="wp-block-group">
+					<!-- wp:paragraph -->
+					<p><strong>©</strong></p>
+					<!-- /wp:paragraph -->
+
+					<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
+				</div>
+				<!-- /wp:group -->
+
+				<!-- wp:paragraph {"lock":{"move":true,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Powered By', 'newspack-block-theme' ); ?>"},"className":"powered-by"} -->
+				<p class="powered-by"><a href="https://newspack.com"><?php esc_html_e( 'Powered by Newspack', 'newspack-block-theme' ); ?></a></p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+
+	</div>
+	<!-- /wp:group -->
+
+</div>
+<!-- /wp:group -->

--- a/theme.json
+++ b/theme.json
@@ -1156,6 +1156,16 @@
 			"area": "footer",
 			"name": "footer",
 			"title": "Footer"
+		},
+    {
+			"area": "footer",
+			"name": "footer-desktop",
+			"title": "Footer (Desktop)"
+		},
+		{
+			"area": "footer",
+			"name": "footer-mobile",
+			"title": "Footer (Mobile)"
 		}
 	],
 	"version": 2,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This uses the same concept as the Header, where the main template part uses 2 "sub" template parts: 1 for desktop and 1 for mobile. These parts then contain a pattern that a publisher can choose from.

The reason for this change is that it doesn't always make sense to have the same footer on both mobile and desktop. For example, some sites have a very complex footer on desktop with many links, which doesn't scale well on mobile. By having two template parts, we give publishers more control over what they want to display depending on the screen size.

_Note: For now, there's only one style for the mobile footer. However, we might add more in the future._

### How to test the changes in this Pull Request:

1. Switch to this PR
2. Switch to a different theme and then switch back to the Block Theme (I noticed some caching issue with patterns in the past and this switch theme "trick" seem to work)
3. Navigate to the Footer template part and see if you see the 2 sub template parts
4. Edit the sub template parts, either by switch pattern or by just modifying the content
5. Save and check your front-end (large and small screen)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
