### PR TITLE
feat: add new harold theme style variation and add body class based on active variation

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -21,6 +21,7 @@ final class Core {
 		\add_action( 'after_setup_theme', [ __CLASS__, 'theme_support' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'theme_styles' ] );
 		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'editor_scripts' ] );
+		\add_filter( 'body_class', [ __CLASS__, 'body_class' ] );
 		\add_filter( 'block_type_metadata', [ __CLASS__, 'block_variations' ] );
 		\add_filter( 'rest_dispatch_request', [ __CLASS__, 'restrict_patterns' ], 12, 3 );
 		\add_filter( 'should_load_remote_block_patterns', '__return_false' );
@@ -83,6 +84,24 @@ final class Core {
 	public static function editor_scripts() {
 		// Enqueue editor JavaScript.
 		wp_enqueue_script( 'editor-script', get_theme_file_uri( '/dist/editor.js' ), array( 'wp-blocks', 'wp-dom' ), wp_get_theme()->get( 'Version' ), true );
+	}
+
+	/**
+	 * Body class.
+	 *
+	 * @since Newspack Block Theme 1.0
+	 *
+	 * @param array $classes Array of body class names.
+	 * @return array Modified array of body class names.
+	 */
+	public static function body_class( $classes ) {
+		$global_settings = wp_get_global_settings();
+
+		$classes[] = 'theme-variation-' . esc_attr(
+			$global_settings['custom']['className'] ?? 'default'
+		);
+
+		return $classes;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Newspack Block Theme ===
 Contributors: Automattic
-Requires at least: 6.5
-Tested up to: 6.6
+Requires at least: 6.2
+Tested up to: 6.8
 Requires PHP: 8.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -13,7 +13,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Copyright ==
 
-Newspack Block Theme WordPress Theme, (C) 2024 Automattic
+Newspack Block Theme WordPress Theme, (C) 2025 Automattic
 Newspack Block Theme is distributed under the terms of the GNU GPL.
 Newspack Block Theme is based on Block Canvas (https://github.com/Automattic/themes/tree/trunk/block-canvas), (C) Automattic, [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)
 

--- a/src/scss/_theme-description.scss
+++ b/src/scss/_theme-description.scss
@@ -4,8 +4,8 @@ Theme URI: https://github.com/automattic/newspack-block-theme
 Author: Automattic
 Author URI: https://newspack.com
 Description: A forward-looking news theme designed and developed to be highly customizable with the WordPress block editor. Brought to you by Newspack: https://newspack.com
-Requires at least: 6.5
-Tested up to: 6.6
+Requires at least: 6.2
+Tested up to: 6.8
 Requires PHP: 8.0
 Version: 1.14.0
 License: GNU General Public License v2 or later

--- a/styles/harold.json
+++ b/styles/harold.json
@@ -1,0 +1,14 @@
+{
+	"title": "Harold",
+	"settings": {
+		"layout": {
+			"contentSize": "784px",
+			"wideSize": "1192px"
+		},
+		"custom": {
+			"className": "harold"
+		}
+	},
+	"version": 2,
+	"$schema": "https://schemas.wp.org/wp/6.2/theme.json"
+}

--- a/styles/paul.json
+++ b/styles/paul.json
@@ -45,64 +45,67 @@
 				}
 			]
 		},
-				"typography": {
-						"fluid": true,
-						"fontFamilies": [
+		"typography": {
+				"fluid": true,
+				"fontFamilies": [
+					{
+						"fontFace": [
 							{
-								"fontFace": [
-									{
-										"fontFamily": "Jost",
-										"fontStretch": "normal",
-										"fontStyle": "normal",
-										"fontWeight": "100 900",
-										"src": [
-											"file:./assets/fonts/jost/Jost-VariableFont_wght.ttf"
-										]
-									},
-									{
-										"fontFamily": "Jost",
-										"fontStretch": "normal",
-										"fontStyle": "italic",
-										"fontWeight": "100 900",
-										"src": [
-											"file:./assets/fonts/jost/Jost-Italic-VariableFont_wght.ttf"
-										]
-									}
-								],
-								"fontFamily": "\"Jost\", sans-serif",
-								"name": "Jost",
-								"slug": "jost"
+								"fontFamily": "Jost",
+								"fontStretch": "normal",
+								"fontStyle": "normal",
+								"fontWeight": "100 900",
+								"src": [
+									"file:./assets/fonts/jost/Jost-VariableFont_wght.ttf"
+								]
 							},
 							{
-								"fontFace": [
-									{
-										"fontFamily": "Newsreader",
-										"fontStretch": "normal",
-										"fontStyle": "normal",
-										"fontWeight": "200 800",
-										"src": [
-											"file:./assets/fonts/newsreader/Newsreader-VariableFont_opsz,wght.ttf"
-										]
-									},
-									{
-										"fontFamily": "Newsreader",
-										"fontStretch": "normal",
-										"fontStyle": "italic",
-										"fontWeight": "200 800",
-										"src": [
-											"file:./assets/fonts/newsreader/Newsreader-Italic-VariableFont_opsz,wght.ttf"
-										]
-									}
-								],
-								"fontFamily": "\"Newsreader\", serif",
-								"name": "Newsreader",
-								"slug": "newsreader"
+								"fontFamily": "Jost",
+								"fontStretch": "normal",
+								"fontStyle": "italic",
+								"fontWeight": "100 900",
+								"src": [
+									"file:./assets/fonts/jost/Jost-Italic-VariableFont_wght.ttf"
+								]
 							}
-						]
-				}
+						],
+						"fontFamily": "\"Jost\", sans-serif",
+						"name": "Jost",
+						"slug": "jost"
+					},
+					{
+						"fontFace": [
+							{
+								"fontFamily": "Newsreader",
+								"fontStretch": "normal",
+								"fontStyle": "normal",
+								"fontWeight": "200 800",
+								"src": [
+									"file:./assets/fonts/newsreader/Newsreader-VariableFont_opsz,wght.ttf"
+								]
+							},
+							{
+								"fontFamily": "Newsreader",
+								"fontStretch": "normal",
+								"fontStyle": "italic",
+								"fontWeight": "200 800",
+								"src": [
+									"file:./assets/fonts/newsreader/Newsreader-Italic-VariableFont_opsz,wght.ttf"
+								]
+							}
+						],
+						"fontFamily": "\"Newsreader\", serif",
+						"name": "Newsreader",
+						"slug": "newsreader"
+					}
+				]
+		},
+		"custom": {
+			"className": "paul"
+		}
 	},
-		"styles": {
-				"typography": {
+	"styles": {
+		"typography": {
 			"fontFamily": "var( --wp--preset--font-family--newsreader )"
 		},
 		"elements": {
@@ -112,7 +115,7 @@
 				}
 			}
 		}
-		},
-		"version": 2,
+	},
+	"version": 2,
 	"$schema": "https://schemas.wp.org/wp/6.2/theme.json"
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Adds a `body_class` based on the theme style variation (if it exists)
* Added a very basic new theme style variation (Harold) which basically has a different content and wide size, which makes nicer "business" sites.