### PR TITLE
feat: update columns breakpoints and use mixins

### DIFF
--- a/src/scss/_sass-utils.scss
+++ b/src/scss/_sass-utils.scss
@@ -29,7 +29,7 @@ $zindex-screen-reader-text: 100000; /* Above WP toolbar. */
 			@content;
 		}
 	} @else if $class == small-only { // stylelint-disable-line block-closing-brace-newline-after
-		@media only screen and (max-width: $medium-screen - 1) {
+		@media only screen and (max-width: ($medium-screen - 1)) {
 			@content;
 		}
 	} @else if $class == medium { // stylelint-disable-line block-closing-brace-newline-after

--- a/src/scss/blocks/_column.scss
+++ b/src/scss/blocks/_column.scss
@@ -1,5 +1,5 @@
 .wp-block-column {
 	&.is-style-rounded {
-		border-radius: var(--wp--custom--border--radius-medium);
+		border-radius: var(--wp--custom--border--radius-large);
 	}
 }

--- a/src/scss/blocks/_columns.scss
+++ b/src/scss/blocks/_columns.scss
@@ -1,5 +1,120 @@
 @use "../sass-utils";
 
+// Define mixin for grid layout (12 columns)
+@mixin grid-layout {
+	&.wp-block-columns {
+		display: grid;
+		grid-template-columns: repeat(12, 1fr);
+	}
+
+	& > * {
+		grid-column: 1 / -1;
+		margin: 0 !important;
+	}
+
+	.wp-block-column {
+		grid-column: auto / span 6;
+	}
+
+	.wp-block-column:only-child {
+		grid-column-end: span 12;
+	}
+
+	/* "33 / 33 / 33" layout */
+	.wp-block-column:not([style*="flex-basis"]):nth-last-child(3):first-child,
+	.wp-block-column:not([style*="flex-basis"]):nth-last-child(3):first-child ~ .wp-block-column {
+		grid-column-end: span 4;
+	}
+
+	/* "25 / 50 / 25" layout */
+	.wp-block-column[style*="25%"] {
+		grid-column-end: span 3;
+	}
+	.wp-block-column[style*="50%"] {
+		grid-column-end: span 6;
+	}
+
+	/* "15 / 70 / 15" layout */
+	.wp-block-column[style*="15%"] {
+		grid-column-end: span 2;
+	}
+	.wp-block-column[style*="70%"] {
+		grid-column-end: span 8;
+	}
+
+	/* "30 / 70" and "70 / 30" layouts */
+	.wp-block-column[style*="33.33%"] {
+		grid-column-end: span 4;
+	}
+	.wp-block-column[style*="66.66%"] {
+		grid-column-end: span 8;
+	}
+}
+
+// Define mixin for small grid layout (6 columns)
+@mixin small-grid-layout {
+	&.wp-block-columns {
+		display: grid;
+		grid-template-columns: repeat(6, 1fr);
+	}
+
+	& > * {
+		grid-column: 1 / -1;
+		margin: 0 !important;
+	}
+
+	.wp-block-column {
+		grid-column: auto / span 3;
+	}
+
+	.wp-block-column:only-child {
+		grid-column-end: span 6;
+	}
+
+	/* "30 / 70" and "70 / 30" layouts */
+	.wp-block-column[style*="33.33%"] {
+		grid-column-end: span 2;
+	}
+	.wp-block-column[style*="66.66%"] {
+		grid-column-end: span 4;
+	}
+}
+
+// Define mixin for sidebar layout
+@mixin sidebar-layout {
+	/* "30 / 70" and "70 / 30" layouts */
+	.wp-block-column[style*="33.33%"] {
+		grid-column: 2 / span 3;
+
+		+ .wp-block-column[style*="66.66%"] {
+			grid-column-start: 6;
+		}
+	}
+
+	.wp-block-column[style*="66.66%"] {
+		grid-column: 2 / span 6;
+
+		+ .wp-block-column[style*="33.33%"] {
+			grid-column-start: 9;
+		}
+
+		.alignleft {
+			margin-left: calc(-1 * ((var(--wp--style--global--wide-size) - (var(--wp--preset--spacing--50) * 11)) / 12 + var(--wp--preset--spacing--50)));
+		}
+
+		.alignright {
+			margin-right: calc(-1 * ((var(--wp--style--global--wide-size) - (var(--wp--preset--spacing--50) * 11)) / 12 + var(--wp--preset--spacing--50)));
+		}
+
+		> :first-child:is(.alignleft),
+		> :first-child:is(.alignright) {
+			+ * {
+				margin-top: 0;
+			}
+		}
+	}
+}
+
 // Experiment: hide column block if empty on smaller screens.
 // This is to prevent odd spacing issues, especially on mobile, but
 // may need to be removed if causing unexpected consiquences.
@@ -50,52 +165,12 @@
 	}
 
 	@include sass-utils.media(x-large) {
-		&.wp-block-columns {
-			display: grid;
-			grid-template-columns: repeat(12, 1fr);
-		}
+		@include grid-layout;
+	}
 
-		& > * {
-			grid-column: 1 / -1;
-			margin: 0 !important;
-		}
-
-		.wp-block-column {
-			grid-column: auto / span 6;
-		}
-
-		.wp-block-column:only-child {
-			grid-column-end: span 12;
-		}
-
-		/* "33 / 33 / 33" layout */
-		.wp-block-column:not([style*="flex-basis"]):nth-last-child(3):first-child,
-		.wp-block-column:not([style*="flex-basis"]):nth-last-child(3):first-child ~ .wp-block-column {
-			grid-column-end: span 4;
-		}
-
-		/* "25 / 50 / 25" layout */
-		.wp-block-column[style*="25%"] {
-			grid-column-end: span 3;
-		}
-		.wp-block-column[style*="50%"] {
-			grid-column-end: span 6;
-		}
-
-		/* "15 / 70 / 15" layout */
-		.wp-block-column[style*="15%"] {
-			grid-column-end: span 2;
-		}
-		.wp-block-column[style*="70%"] {
-			grid-column-end: span 8;
-		}
-
-		/* "30 / 70" and "70 / 30" layouts */
-		.wp-block-column[style*="33.33%"] {
-			grid-column-end: span 4;
-		}
-		.wp-block-column[style*="66.66%"] {
-			grid-column-end: span 8;
+	.theme-variation-harold & {
+		@include sass-utils.media(large) {
+			@include grid-layout;
 		}
 	}
 
@@ -113,6 +188,12 @@
 
 			@include sass-utils.media(x-large) {
 				display: inherit;
+			}
+
+			.theme-variation-harold & {
+				@include sass-utils.media(large) {
+					display: inherit;
+				}
 			}
 		}
 
@@ -154,36 +235,12 @@
 		}
 
 		@include sass-utils.media(x-large) {
-			/* "30 / 70" and "70 / 30" layouts */
-			.wp-block-column[style*="33.33%"] {
-				grid-column: 2 / span 3;
+			@include sidebar-layout;
+		}
 
-				+ .wp-block-column[style*="66.66%"] {
-					grid-column-start: 6;
-				}
-			}
-
-			.wp-block-column[style*="66.66%"] {
-				grid-column: 2 / span 6;
-
-				+ .wp-block-column[style*="33.33%"] {
-					grid-column-start: 9;
-				}
-
-				.alignleft {
-					margin-left: calc(-1 * ((var(--wp--style--global--wide-size) - (var(--wp--preset--spacing--50) * 11)) / 12 + var(--wp--preset--spacing--50)));
-				}
-
-				.alignright {
-					margin-right: calc(-1 * ((var(--wp--style--global--wide-size) - (var(--wp--preset--spacing--50) * 11)) / 12 + var(--wp--preset--spacing--50)));
-				}
-
-				> :first-child:is(.alignleft),
-				> :first-child:is(.alignright) {
-					+ * {
-						margin-top: 0;
-					}
-				}
+		.theme-variation-harold & {
+			@include sass-utils.media(large) {
+				@include sidebar-layout;
 			}
 		}
 	}
@@ -198,32 +255,15 @@
 	}
 }
 
+// Newspack Small Grid
 .newspack-grid-small {
 	@include sass-utils.media(x-large) {
-		&.wp-block-columns {
-			display: grid;
-			grid-template-columns: repeat(6, 1fr);
-		}
+		@include small-grid-layout;
+	}
 
-		& > * {
-			grid-column: 1 / -1;
-			margin: 0 !important;
-		}
-
-		.wp-block-column {
-			grid-column: auto / span 3;
-		}
-
-		.wp-block-column:only-child {
-			grid-column-end: span 6;
-		}
-
-		/* "30 / 70" and "70 / 30" layouts */
-		.wp-block-column[style*="33.33%"] {
-			grid-column-end: span 2;
-		}
-		.wp-block-column[style*="66.66%"] {
-			grid-column-end: span 4;
+	.theme-variation-harold & {
+		@include sass-utils.media(large) {
+			@include small-grid-layout;
 		}
 	}
 }

--- a/styles/harold.json
+++ b/styles/harold.json
@@ -2,8 +2,8 @@
 	"title": "Harold",
 	"settings": {
 		"layout": {
-			"contentSize": "784px",
-			"wideSize": "1192px"
+			"contentSize": "800px",
+			"wideSize": "1216px"
 		},
 		"custom": {
 			"className": "harold"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When using the Harold variation, we don't need the `x-large` breakpoint since the grid is narrower (note: I've slightly modified the contentSize and wideSize to better fit within the `large` breakpoint.
So the grid layouts are now mixins so we can reuse the code and apply the correct breakpoint based on the theme style variation.