### PR TITLE
fix: have header inherit position if mobile or desktop header has a custom position

### DIFF
--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -60,25 +60,49 @@ ol {
 }
 
 // Position
+@mixin header-position($position) {
+	header:has(&) {
+		position: $position;
+		top: 0;
+		z-index: sass-utils.$zindex-fixed-element;
+
+		.admin-bar & {
+			@include sass-utils.media(small) {
+				top: var(--wp-admin--admin-bar--height);
+			}
+		}
+
+		&:has(.is-position-#{$position}--mobile-only),
+		&:has(.header-desktop:not(.is-position-#{$position})) {
+			@include sass-utils.media(medium) {
+				position: inherit;
+			}
+		}
+
+		&:has(.is-position-#{$position}--desktop-only),
+		&:has(.header-mobile:not(.is-position-#{$position})) {
+			@include sass-utils.media(small-only) {
+				position: inherit;
+			}
+		}
+	}
+}
+
 .is-position {
 	&-fixed {
 		position: fixed;
+		@include header-position(fixed);
 	}
 
 	&-sticky {
 		position: sticky;
+		@include header-position(sticky);
 	}
 
 	&-fixed,
 	&-sticky {
 		top: 0;
 		z-index: sass-utils.$zindex-fixed-element;
-
-		.admin-bar &:is(header) {
-			@include sass-utils.media(small) {
-				top: var(--wp-admin--admin-bar--height);
-			}
-		}
 
 		&--mobile-only {
 			@include sass-utils.media(medium) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This allows user to add the `is-position-{fixed|sticky}` to the mobile or desktop header to the (main) Header template part so the main "Header" inherits the correct position.

### How to test the changes in this Pull Request:

1. Add `is-position-sticky` to the desktop-header
2. Check the front-end and see it doesn't work (because the parent – `<header>` – doesn't have the sticky position)
3. Switch to this branch and refresh front-end
4. The header show now be sticky on desktop only

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
