### PR TITLE
feat: add basic woocommerce support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -24,3 +24,4 @@ require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-core.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/blocks/index.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-patterns.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-jetpack.php';
+require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-woocommerce.php';

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Newspack Block Theme WooCommerce integration.
+ *
+ * @link https://woocommerce.com/
+ *
+ * @package Newspack_Block_Theme
+ */
+
+namespace Newspack_Block_Theme;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce integration class.
+ * Handles all WooCommerce-specific functionality and theme support.
+ */
+final class WooCommerce {
+	/**
+	 * Initializer.
+	 */
+	public static function init() {
+		// Only initialize if WooCommerce is active.
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return;
+		}
+
+		// This theme doesn't have a traditional sidebar.
+		\remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
+
+		// Register theme features.
+		\add_action( 'after_setup_theme', [ __CLASS__, 'theme_support' ] );
+		\add_filter( 'hooked_block_types', [ __CLASS__, 'remove_wc_hooked_blocks' ], 10, 4 );
+	}
+
+	/**
+	 * Add WooCommerce theme support.
+	 *
+	 * @since Newspack Block Theme 1.0
+	 *
+	 * @return void
+	 */
+	public static function theme_support() {
+		\add_theme_support(
+			'woocommerce',
+			[
+				'thumbnail_image_width' => 300,
+				'single_image_width'    => 1296,
+			]
+		);
+		\add_theme_support( 'wc-product-gallery-zoom' );
+		\add_theme_support( 'wc-product-gallery-lightbox' );
+		\add_theme_support( 'wc-product-gallery-slider' );
+	}
+
+	/**
+	 * Remove WooCommerce blocks from being hooked into navigation blocks.
+	 *
+	 * Filters the list of hooked block types to remove WooCommerce blocks.
+	 *
+	 * @since Newspack Block Theme 1.0
+	 *
+	 * @param array  $hooked_block_types The list of hooked block types.
+	 * @param string $position           The relative position of the hooked blocks.
+	 * @param string $anchor_block_type  The anchor block type.
+	 * @param array  $context            The block context.
+	 * @return array Modified list of hooked block types with WooCommerce blocks removed.
+	 */
+	public static function remove_wc_hooked_blocks( $hooked_block_types, $position, $anchor_block_type, $context ) {
+		// Only filter navigation blocks.
+		if ( 'core/navigation' !== $anchor_block_type ) {
+			return $hooked_block_types;
+		}
+
+		// Remove WooCommerce blocks from being hooked.
+		$wc_blocks_to_remove = [
+			'woocommerce/mini-cart',
+			'woocommerce/customer-account',
+		];
+
+		foreach ( $wc_blocks_to_remove as $block_type ) {
+			$key = array_search( $block_type, $hooked_block_types, true );
+			if ( false !== $key ) {
+				unset( $hooked_block_types[ $key ] );
+			}
+		}
+
+		return $hooked_block_types;
+	}
+}
+
+WooCommerce::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds basic WooCommerce support. It also makes sure WC blocks aren't being hooked into navigation blocks.

_Note: There's a conflict with Newspack Plugin so you must have `define( 'NEWSPACK_DISABLE_WC_TEMPLATE_OVERRIDE', true );` in your `config.php` file.

### How to test the changes in this Pull Request:

1. Make sure your `config.php` file has `define( 'NEWSPACK_DISABLE_WC_TEMPLATE_OVERRIDE', true );`
2. Test if you see standard WC pages (e.g. /my-account)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
