### PR TITLE
feat(byline): add byline block support to patterns and templates

### DIFF
--- a/patterns/post-meta/post-meta-compact.php
+++ b/patterns/post-meta/post-meta-compact.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Title: Compact Byline and Date
+ * Slug: newspack-block-theme/post-meta-compact
+ * Categories: newspack-block-theme-post-meta
+ * Viewport Width: 632
+ * Inserter: yes
+ * Block Types: newspack/byline, core/post-author, core/post-date
+ *
+ * @package Newspack_Block_Theme
+ */
+
+$registry = WP_Block_Type_Registry::get_instance();
+?>
+<!-- wp:group {"metadata":{"name":"Post Meta"},"className":"post-meta","style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group post-meta">
+
+<?php if ( $registry->get_registered( 'newspack/byline' ) ) : ?>
+
+	<!-- wp:newspack/byline {"fontSize":"x-small"} /-->
+
+<?php else : ?>
+
+	<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"fontSize":"x-small"} /-->
+
+<?php endif; ?>
+
+<!-- wp:post-date {"fontSize":"x-small"} /-->
+
+</div>
+<!-- /wp:group -->

--- a/patterns/post-meta/post-meta-multiple-lines-avatar.php
+++ b/patterns/post-meta/post-meta-multiple-lines-avatar.php
@@ -5,7 +5,7 @@
  * Categories: newspack-block-theme-post-meta
  * Viewport Width: 632
  * Inserter: yes
- * Block Types: core/avatar, core/post-author, core/post-date, jetpack/sharing-buttons
+ * Block Types: newspack/byline, newspack/avatar, core/avatar, core/post-author, core/post-date, jetpack/sharing-buttons
  *
  * @package Newspack_Block_Theme
  */

--- a/patterns/post-meta/post-meta-multiple-lines-avatar.php
+++ b/patterns/post-meta/post-meta-multiple-lines-avatar.php
@@ -22,12 +22,6 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 	<!-- wp:newspack/avatar {"size":48,"linkToAuthorArchive":true,"lock":{"move":true,"remove":true}} /-->
 
-<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
-
-	<!-- wp:co-authors-plus/coauthors {"layout":{"type":"flex","orientation":"horizontal","flexWrap":"nowrap"},"lock":{"move":true,"remove":true},"style":{"layout":{"selfStretch":"fit"},"spacing":{"blockGap":"0"}},"className":"cap-avatar"} -->
-	<div class="wp-block-co-authors-plus-coauthors cap-avatar"><!-- wp:co-authors-plus/avatar {"size":48} /--></div>
-	<!-- /wp:co-authors-plus/coauthors -->
-
 <?php else : ?>
 
 	<!-- wp:avatar {"size":48,"lock":{"move":true,"remove":true}} /-->
@@ -40,12 +34,6 @@ $registry = WP_Block_Type_Registry::get_instance();
 <?php if ( $registry->get_registered( 'newspack/byline' ) ) : ?>
 
 	<!-- wp:newspack/byline {"lock":{"move":true,"remove":true}} /-->
-
-<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
-
-	<!-- wp:co-authors-plus/coauthors -->
-	<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name {"isLink":true} /--></div>
-	<!-- /wp:co-authors-plus/coauthors -->
 
 <?php else : ?>
 

--- a/patterns/post-meta/post-meta-multiple-lines-avatar.php
+++ b/patterns/post-meta/post-meta-multiple-lines-avatar.php
@@ -18,7 +18,11 @@ $registry = WP_Block_Type_Registry::get_instance();
 <!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Meta"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
 <div class="wp-block-group">
 
-<?php if ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
+<?php if ( $registry->get_registered( 'newspack/byline' ) ) : ?>
+
+	<!-- wp:newspack/avatar {"size":48,"linkToAuthorArchive":true,"lock":{"move":true,"remove":true}} /-->
+
+<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
 
 	<!-- wp:co-authors-plus/coauthors {"layout":{"type":"flex","orientation":"horizontal","flexWrap":"nowrap"},"lock":{"move":true,"remove":true},"style":{"layout":{"selfStretch":"fit"},"spacing":{"blockGap":"0"}},"className":"cap-avatar"} -->
 	<div class="wp-block-co-authors-plus-coauthors cap-avatar"><!-- wp:co-authors-plus/avatar {"size":48} /--></div>
@@ -33,7 +37,11 @@ $registry = WP_Block_Type_Registry::get_instance();
 <!-- wp:group {"templateLock":"all","lock":{"move":true,"remove":true},"metadata":{"name":"Byline + Date"},"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group">
 
-<?php if ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
+<?php if ( $registry->get_registered( 'newspack/byline' ) ) : ?>
+
+	<!-- wp:newspack/byline {"lock":{"move":true,"remove":true}} /-->
+
+<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
 
 	<!-- wp:co-authors-plus/coauthors -->
 	<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name {"isLink":true} /--></div>

--- a/patterns/post-meta/post-meta-multiple-lines.php
+++ b/patterns/post-meta/post-meta-multiple-lines.php
@@ -5,7 +5,7 @@
  * Categories: newspack-block-theme-post-meta
  * Viewport Width: 632
  * Inserter: yes
- * Block Types: core/post-author, core/post-date, jetpack/sharing-buttons
+ * Block Types: newspack/byline, core/post-author, core/post-date, jetpack/sharing-buttons
  *
  * @package Newspack_Block_Theme
  */

--- a/patterns/post-meta/post-meta-multiple-lines.php
+++ b/patterns/post-meta/post-meta-multiple-lines.php
@@ -22,12 +22,6 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 	<!-- wp:newspack/byline {"lock":{"move":true,"remove":true}} /-->
 
-<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
-
-	<!-- wp:co-authors-plus/coauthors {"lock":{"move":true,"remove":true}} -->
-	<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name {"isLink":true,"lock":{"move":true,"remove":true}} /--></div>
-	<!-- /wp:co-authors-plus/coauthors -->
-
 <?php else : ?>
 
 	<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"lock":{"move":true,"remove":true}} /-->

--- a/patterns/post-meta/post-meta-multiple-lines.php
+++ b/patterns/post-meta/post-meta-multiple-lines.php
@@ -18,7 +18,11 @@ $registry = WP_Block_Type_Registry::get_instance();
 <!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Meta"},"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 <div class="wp-block-group">
 
-<?php if ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
+<?php if ( $registry->get_registered( 'newspack/byline' ) ) : ?>
+
+	<!-- wp:newspack/byline {"lock":{"move":true,"remove":true}} /-->
+
+<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
 
 	<!-- wp:co-authors-plus/coauthors {"lock":{"move":true,"remove":true}} -->
 	<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name {"isLink":true,"lock":{"move":true,"remove":true}} /--></div>

--- a/patterns/post-meta/post-meta-single-line-avatar.php
+++ b/patterns/post-meta/post-meta-single-line-avatar.php
@@ -5,7 +5,7 @@
  * Categories: newspack-block-theme-post-meta
  * Viewport Width: 632
  * Inserter: yes
- * Block Types: core/avatar, core/post-author, core/post-date, jetpack/sharing-buttons
+ * Block Types: newspack/byline, newspack/avatar, core/avatar, core/post-author, core/post-date, jetpack/sharing-buttons
  *
  * @package Newspack_Block_Theme
  */

--- a/patterns/post-meta/post-meta-single-line-avatar.php
+++ b/patterns/post-meta/post-meta-single-line-avatar.php
@@ -30,22 +30,6 @@ $registry = WP_Block_Type_Registry::get_instance();
 	</div>
 	<!-- /wp:group -->
 
-<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
-
-	<!-- wp:group {"templateLock":"all","lock":{"move":true,"remove":true},"metadata":{"name":"Avatar + Byline"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-	<div class="wp-block-group">
-
-	<!-- wp:co-authors-plus/coauthors {"layout":{"type":"flex","orientation":"horizontal"},"prefix":"","style":{"spacing":{"blockGap":"0"}},"className":"cap-avatar"} -->
-	<div class="wp-block-co-authors-plus-coauthors cap-avatar"><!-- wp:co-authors-plus/avatar /--></div>
-	<!-- /wp:co-authors-plus/coauthors -->
-
-	<!-- wp:co-authors-plus/coauthors {"lock":{"move":true,"remove":true}} -->
-	<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name {"isLink":true,"lock":{"move":true,"remove":true}} /--></div>
-	<!-- /wp:co-authors-plus/coauthors -->
-
-	</div>
-	<!-- /wp:group -->
-
 <?php else : ?>
 
 	<!-- wp:post-author {"avatarSize":24,"byline":"By","isLink":true,"lock":{"move":true,"remove":true}} /-->

--- a/patterns/post-meta/post-meta-single-line-avatar.php
+++ b/patterns/post-meta/post-meta-single-line-avatar.php
@@ -18,7 +18,19 @@ $registry = WP_Block_Type_Registry::get_instance();
 <!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Meta"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","verticalAlignment":"center"}} -->
 <div class="wp-block-group">
 
-<?php if ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
+<?php if ( $registry->get_registered( 'newspack/byline' ) ) : ?>
+
+	<!-- wp:group {"templateLock":"all","lock":{"move":true,"remove":true},"metadata":{"name":"Avatar + Byline"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group">
+
+	<!-- wp:newspack/avatar {"size":24,"linkToAuthorArchive":true,"lock":{"move":true,"remove":true}} /-->
+
+	<!-- wp:newspack/byline {"lock":{"move":true,"remove":true}} /-->
+
+	</div>
+	<!-- /wp:group -->
+
+<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
 
 	<!-- wp:group {"templateLock":"all","lock":{"move":true,"remove":true},"metadata":{"name":"Avatar + Byline"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group">

--- a/patterns/post-meta/post-meta-single-line.php
+++ b/patterns/post-meta/post-meta-single-line.php
@@ -5,7 +5,7 @@
  * Categories: newspack-block-theme-post-meta
  * Viewport Width: 632
  * Inserter: yes
- * Block Types: core/post-author, core/post-date, jetpack/sharing-buttons
+ * Block Types: newspack/byline, core/post-author, core/post-date, jetpack/sharing-buttons
  *
  * @package Newspack_Block_Theme
  */

--- a/patterns/post-meta/post-meta-single-line.php
+++ b/patterns/post-meta/post-meta-single-line.php
@@ -22,13 +22,6 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 	<!-- wp:newspack/byline {"lock":{"move":true,"remove":true}} /-->
 
-<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
-
-	<!-- wp:co-authors-plus/coauthors {"lock":{"move":true,"remove":true}} -->
-	<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name {"isLink":true,"lock":{"move":true,"remove":true}} /--></div>
-
-	<!-- /wp:co-authors-plus/coauthors -->
-
 <?php else : ?>
 
 	<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"lock":{"move":true,"remove":true}} /-->

--- a/patterns/post-meta/post-meta-single-line.php
+++ b/patterns/post-meta/post-meta-single-line.php
@@ -18,7 +18,11 @@ $registry = WP_Block_Type_Registry::get_instance();
 <!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Meta"},"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","verticalAlignment":"center"}} -->
 <div class="wp-block-group">
 
-<?php if ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
+<?php if ( $registry->get_registered( 'newspack/byline' ) ) : ?>
+
+	<!-- wp:newspack/byline {"lock":{"move":true,"remove":true}} /-->
+
+<?php elseif ( $registry->get_registered( 'co-authors-plus/coauthors' ) ) : ?>
 
 	<!-- wp:co-authors-plus/coauthors {"lock":{"move":true,"remove":true}} -->
 	<div class="wp-block-co-authors-plus-coauthors"><!-- wp:co-authors-plus/name {"isLink":true,"lock":{"move":true,"remove":true}} /--></div>

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -38,13 +38,7 @@
 
 						<!-- wp:post-excerpt {"showMoreOnNewLine":false,"fontSize":"small"} /-->
 
-						<!-- wp:group {"metadata":{"name":"Post Meta"},"className":"post-meta","style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-						<div class="wp-block-group post-meta">
-							<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"fontSize":"x-small"} /-->
-
-							<!-- wp:post-date {"fontSize":"x-small"} /-->
-						</div>
-						<!-- /wp:group -->
+						<!-- wp:pattern {"slug":"newspack-block-theme/post-meta-compact"} /-->
 					</div>
 					<!-- /wp:column -->
 				</div>

--- a/templates/author.html
+++ b/templates/author.html
@@ -38,13 +38,7 @@
 
 						<!-- wp:post-excerpt {"showMoreOnNewLine":false,"fontSize":"small"} /-->
 
-						<!-- wp:group {"metadata":{"name":"Post Meta"},"className":"post-meta","style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-						<div class="wp-block-group post-meta">
-							<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"fontSize":"x-small"} /-->
-
-							<!-- wp:post-date {"fontSize":"x-small"} /-->
-						</div>
-						<!-- /wp:group -->
+						<!-- wp:pattern {"slug":"newspack-block-theme/post-meta-compact"} /-->
 					</div>
 					<!-- /wp:column -->
 				</div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -30,13 +30,7 @@
 
 						<!-- wp:post-excerpt {"showMoreOnNewLine":false,"fontSize":"small"} /-->
 
-						<!-- wp:group {"metadata":{"name":"Post Meta"},"className":"post-meta","style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-						<div class="wp-block-group post-meta">
-							<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"fontSize":"x-small"} /-->
-
-							<!-- wp:post-date {"fontSize":"x-small"} /-->
-						</div>
-						<!-- /wp:group -->
+						<!-- wp:pattern {"slug":"newspack-block-theme/post-meta-compact"} /-->
 					</div>
 					<!-- /wp:column -->
 				</div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -40,13 +40,7 @@
 
 					<!-- wp:post-excerpt {"showMoreOnNewLine":false,"fontSize":"small"} /-->
 
-					<!-- wp:group {"metadata":{"name":"Post Meta"},"className":"post-meta","style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-					<div class="wp-block-group post-meta">
-						<!-- wp:post-author {"showAvatar":false,"byline":"By","isLink":true,"fontSize":"x-small"} /-->
-
-						<!-- wp:post-date {"fontSize":"x-small"} /-->
-					</div>
-					<!-- /wp:group -->
+					<!-- wp:pattern {"slug":"newspack-block-theme/post-meta-compact"} /-->
 				</div>
 				<!-- /wp:column -->
 				</div>

--- a/theme.json
+++ b/theme.json
@@ -949,6 +949,33 @@
 					"fontSize": "var( --wp--preset--font-size--small )",
 					"lineHeight": "var( --wp--custom--line-height--small )"
 				}
+			},
+			"newspack/byline": {
+				"color": {
+					"text": "var( --wp--preset--color--contrast-3 )"
+				},
+				"elements": {
+					"link": {
+						"color": {
+							"text": "var( --wp--preset--color--contrast-3 )"
+						},
+						":hover": {
+							"color": {
+								"text": "var( --wp--preset--color--contrast )"
+							},
+							"typography": {
+								"textDecoration": "none"
+							}
+						},
+						"typography": {
+							"textDecoration": "underline"
+						}
+					}
+				},
+				"typography": {
+					"fontSize": "var( --wp--preset--font-size--x-small )",
+					"lineHeight": "var( --wp--custom--line-height--x-small )"
+				}
 			}
 		},
 		"color": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updates post-meta patterns to prioritize the new `newspack/byline` block when available.

Pattern priority order:
1. `newspack/byline` - when Newspack plugin is active
2. `co-authors-plus/coauthors` - when CAP is active without Newspack
3. `core/post-author` - fallback

This enables custom bylines and unified author display in block theme templates.

Requires: https://github.com/Automattic/newspack-plugin/pull/4405

Closes # NPPD-1122.

 ---

**Feedback requested:** Should we keep the CAP fallback? The block theme is typically used with Newspack, so the `elseif` for `co-authors-plus/coauthors` may be unnecessary. We could simplify to just `newspack/byline` > `core/post-author`. Thoughts?

---

### How to test the changes in this Pull Request:

1. Activate `newspack-block-theme` with Newspack plugin (byline block branch).
2. View a single post and verify the author byline displays correctly.
3. Check Site Editor > post-meta patterns should use `newspack/byline` block.
4. Deactivate Newspack plugin > patterns should fall back to CAP or core/post-author.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?