### PR TITLE
fix: dequeue some Woo styles from the theme

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -31,6 +31,10 @@ final class WooCommerce {
 		// Register theme features.
 		\add_action( 'after_setup_theme', [ __CLASS__, 'theme_support' ] );
 		\add_filter( 'hooked_block_types', [ __CLASS__, 'remove_wc_hooked_blocks' ], 10, 4 );
+
+		// Remove WooCommerce styles.
+		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'remove_woocommerce_blocktheme_styles' ], 100 );
+		\add_filter( 'woocommerce_enqueue_styles', [ __CLASS__, 'remove_woocommerce_general_styles' ] );
 	}
 
 	/**
@@ -51,6 +55,31 @@ final class WooCommerce {
 		\add_theme_support( 'wc-product-gallery-zoom' );
 		\add_theme_support( 'wc-product-gallery-lightbox' );
 		\add_theme_support( 'wc-product-gallery-slider' );
+	}
+
+	/**
+	 * Remove WooCommerce block theme styles.
+	 *
+	 * @since Newspack Block Theme 1.0.22
+	 *
+	 * @return void
+	 */
+	public static function remove_woocommerce_blocktheme_styles() {
+		\wp_dequeue_style( 'woocommerce-blocktheme' );
+		\wp_deregister_style( 'woocommerce-blocktheme' );
+	}
+
+	/**
+	 * Remove WooCommerce general styles.
+	 *
+	 * @since Newspack Block Theme 1.0.22
+	 *
+	 * @param array $enqueue_styles The styles to enqueue.
+	 * @return array The modified styles.
+	 */
+	public static function remove_woocommerce_general_styles( $enqueue_styles ) {
+		unset( $enqueue_styles['woocommerce-general'] );
+		return $enqueue_styles;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR dequeues Woo's general styles and its block theme styles so they don't override/interfere as much with the My Account styles.

See NPPD-1124

### How to test the changes in this Pull Request:

This one's a little tough to test because while it makes My Account look closer to right, it won't fix every issue. 

1. Apply this PR.
2. Set your test site to use My Account v1 (`define( 'NEWSPACK_MY_ACCOUNT_VERSION', '1.0.0' );`)
3. As a reader, view the My Account screens and confirm they look close-ish to how they look with the Classic theme. You can also compare them to how they look in the block theme before this PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
