### PR TITLE
feat: add My Account button block to all header patterns

### DIFF
--- a/patterns/header/header-desktop-style-1.php
+++ b/patterns/header/header-desktop-style-1.php
@@ -26,7 +26,7 @@
 			<!-- /wp:buttons -->
 
 			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
-				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-small-size","fontSize":"x-small"} /-->
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base-2","textColor":"contrast","className":"has-small-size","fontSize":"x-small"} /-->
 			<?php endif; ?>
 		</div>
 		<!-- /wp:group -->

--- a/patterns/header/header-desktop-style-2.php
+++ b/patterns/header/header-desktop-style-2.php
@@ -12,7 +12,32 @@
 <!-- wp:group {"lock":{"move":true,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Header (Desktop)', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"0","right":"var:preset|spacing|30","left":"var:preset|spacing|30"},"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|80"}}},"backgroundColor":"base","layout":{"type":"constrained"}} -->
 <div class="wp-block-group has-base-background-color has-background" style="margin-bottom:var(--wp--preset--spacing--80);padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:0;padding-left:var(--wp--preset--spacing--30)">
 
-	<!-- wp:site-logo {"width":256,"align":"center","lock":{"move":true,"remove":true}} /-->
+	<!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+	<div class="wp-block-columns alignwide are-vertically-aligned-center">
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:site-logo {"width":256,"align":"center","lock":{"move":true,"remove":true}} /-->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
+				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+				<div class="wp-block-group">
+					<!-- wp:newspack/my-account-button {"className":"has-x-small-size","fontSize":"x-small"} /-->
+				</div>
+				<!-- /wp:group -->
+			<?php endif; ?>
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Menu', 'newspack-block-theme' ); ?>"},"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"center"}} -->
 	<div class="wp-block-group alignwide">

--- a/patterns/header/header-desktop-style-2.php
+++ b/patterns/header/header-desktop-style-2.php
@@ -30,7 +30,7 @@
 			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
 				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 				<div class="wp-block-group">
-					<!-- wp:newspack/my-account-button {"className":"has-x-small-size","fontSize":"x-small"} /-->
+					<!-- wp:newspack/my-account-button {"className":"has-small-size","fontSize":"x-small"} /-->
 				</div>
 				<!-- /wp:group -->
 			<?php endif; ?>

--- a/patterns/header/header-desktop-style-2.php
+++ b/patterns/header/header-desktop-style-2.php
@@ -30,7 +30,7 @@
 			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
 				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 				<div class="wp-block-group">
-					<!-- wp:newspack/my-account-button {"className":"has-small-size","fontSize":"x-small"} /-->
+					<!-- wp:newspack/my-account-button {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base-2","textColor":"contrast","className":"has-small-size","fontSize":"x-small"} /-->
 				</div>
 				<!-- /wp:group -->
 			<?php endif; ?>

--- a/patterns/header/header-desktop-style-3.php
+++ b/patterns/header/header-desktop-style-3.php
@@ -30,11 +30,11 @@
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 			<div class="wp-block-group">
-				<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","align":"right","className":"search-menu"} /-->
-
 				<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
 					<!-- wp:newspack/my-account-button {"className":"has-small-size","fontSize":"x-small"} /-->
 				<?php endif; ?>
+
+				<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","align":"right","className":"search-menu"} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>

--- a/patterns/header/header-desktop-style-3.php
+++ b/patterns/header/header-desktop-style-3.php
@@ -28,7 +28,15 @@
 
 		<!-- wp:column {"verticalAlignment":"center","width":"25%"} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:25%">
-			<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","align":"right","className":"search-menu"} /-->
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+			<div class="wp-block-group">
+				<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","align":"right","className":"search-menu"} /-->
+
+				<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
+					<!-- wp:newspack/my-account-button {"className":"has-small-size","fontSize":"x-small"} /-->
+				<?php endif; ?>
+			</div>
+			<!-- /wp:group -->
 		</div>
 		<!-- /wp:column -->
 	</div>

--- a/patterns/header/header-desktop-style-3.php
+++ b/patterns/header/header-desktop-style-3.php
@@ -31,7 +31,7 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 			<div class="wp-block-group">
 				<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
-					<!-- wp:newspack/my-account-button {"className":"has-small-size","fontSize":"x-small"} /-->
+					<!-- wp:newspack/my-account-button {"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base-2","textColor":"contrast","className":"has-small-size","fontSize":"x-small"} /-->
 				<?php endif; ?>
 
 				<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","align":"right","className":"search-menu"} /-->

--- a/patterns/header/header-desktop-style-4.php
+++ b/patterns/header/header-desktop-style-4.php
@@ -37,7 +37,7 @@
 				<!-- /wp:buttons -->
 
 				<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
-					<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-small-size","fontSize":"x-small"} /-->
+					<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base-2","textColor":"contrast","className":"has-small-size","fontSize":"x-small"} /-->
 				<?php endif; ?>
 			</div>
 			<!-- /wp:group -->

--- a/patterns/header/header-desktop-style-4.php
+++ b/patterns/header/header-desktop-style-4.php
@@ -26,15 +26,21 @@
 
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:buttons {"lock":{"move":true,"remove":false},"className":"has-small-size","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"fontSize":"x-small"} -->
-			<div class="wp-block-buttons has-custom-font-size has-small-size has-x-small-font-size">
-				<!-- wp:button -->
-				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Donate', 'newspack-block-theme' ); ?></a>
+			<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+			<div class="wp-block-group">
+				<!-- wp:buttons {"lock":{"move":true,"remove":false},"className":"has-small-size","style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"fontSize":"x-small"} -->
+				<div class="wp-block-buttons has-custom-font-size has-small-size has-x-small-font-size">
+					<!-- wp:button -->
+					<div class="wp-block-button"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Donate', 'newspack-block-theme' ); ?></a></div>
+					<!-- /wp:button -->
 				</div>
-				<!-- /wp:button -->
+				<!-- /wp:buttons -->
+
+				<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
+					<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-small-size","fontSize":"x-small"} /-->
+				<?php endif; ?>
 			</div>
-			<!-- /wp:buttons -->
+			<!-- /wp:group -->
 
 			<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","align":"right","className":"search-menu"} /-->
 		</div>

--- a/patterns/header/header-desktop-style-5.php
+++ b/patterns/header/header-desktop-style-5.php
@@ -37,7 +37,7 @@
 			<!-- wp:site-logo {"width":256} /-->
 
 			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
-				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-small-size","fontSize":"x-small"} /-->
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base-2","textColor":"contrast","className":"has-small-size","fontSize":"x-small"} /-->
 			<?php endif; ?>
 		</div>
 		<!-- /wp:group -->

--- a/patterns/header/header-desktop-style-5.php
+++ b/patterns/header/header-desktop-style-5.php
@@ -35,6 +35,10 @@
 		<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 		<div class="wp-block-group alignwide">
 			<!-- wp:site-logo {"width":256} /-->
+
+			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-small-size","fontSize":"x-small"} /-->
+			<?php endif; ?>
 		</div>
 		<!-- /wp:group -->
 	</div>

--- a/patterns/header/header-mobile-style-1.php
+++ b/patterns/header/header-mobile-style-1.php
@@ -34,7 +34,7 @@
 			<!-- /wp:buttons -->
 
 			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
-				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-x-small-size","fontSize":"x-small"} /-->
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base-2","textColor":"contrast","className":"has-x-small-size","fontSize":"x-small"} /-->
 			<?php endif; ?>
 		</div>
 		<!-- /wp:group -->

--- a/patterns/header/header-mobile-style-1.php
+++ b/patterns/header/header-mobile-style-1.php
@@ -23,8 +23,6 @@
 		</div>
 		<!-- /wp:group -->
 
-
-
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
 			<!-- wp:buttons {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->

--- a/patterns/header/header-mobile-style-1.php
+++ b/patterns/header/header-mobile-style-1.php
@@ -23,6 +23,8 @@
 		</div>
 		<!-- /wp:group -->
 
+
+
 		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 		<div class="wp-block-group">
 			<!-- wp:buttons {"layout":{"type":"flex","flexWrap":"nowrap"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
@@ -32,8 +34,13 @@
 				<!-- /wp:button -->
 			</div>
 			<!-- /wp:buttons -->
+
+			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-x-small-size","fontSize":"x-small"} /-->
+			<?php endif; ?>
 		</div>
 		<!-- /wp:group -->
+
 	</div>
 	<!-- /wp:group -->
 

--- a/patterns/header/header-mobile-style-2.php
+++ b/patterns/header/header-mobile-style-2.php
@@ -19,15 +19,7 @@
 
 		<!-- wp:site-logo {"width":256,"lock":{"move":false,"remove":true}} /-->
 
-		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group">
-			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
-				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-x-small-size","fontSize":"x-small"} /-->
-			<?php endif; ?>
-
-			<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","className":"search-menu"} /-->
-		</div>
-		<!-- /wp:group -->
+		<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","className":"search-menu"} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/patterns/header/header-mobile-style-2.php
+++ b/patterns/header/header-mobile-style-2.php
@@ -19,7 +19,15 @@
 
 		<!-- wp:site-logo {"width":256,"lock":{"move":false,"remove":true}} /-->
 
-		<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","className":"search-menu"} /-->
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+		<div class="wp-block-group">
+			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-x-small-size","fontSize":"x-small"} /-->
+			<?php endif; ?>
+
+			<!-- wp:template-part {"slug":"search-menu","theme":"newspack-block-theme","tagName":"div","className":"search-menu"} /-->
+		</div>
+		<!-- /wp:group -->
 	</div>
 	<!-- /wp:group -->
 

--- a/patterns/header/header-mobile-style-3.php
+++ b/patterns/header/header-mobile-style-3.php
@@ -27,6 +27,10 @@
 			</div>
 			<!-- /wp:buttons -->
 
+			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-x-small-size","fontSize":"x-small"} /-->
+			<?php endif; ?>
+
 			<!-- wp:template-part {"slug":"mobile-menu","theme":"newspack-block-theme","tagName":"div","lock":{"move":false,"remove":true},"className":"mobile-menu"} /-->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/header/header-mobile-style-3.php
+++ b/patterns/header/header-mobile-style-3.php
@@ -28,7 +28,7 @@
 			<!-- /wp:buttons -->
 
 			<?php if ( class_exists( 'Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) : ?>
-				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"className":"has-x-small-size","fontSize":"x-small"} /-->
+				<!-- wp:newspack/my-account-button {"lock":{"move":true,"remove":false},"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"backgroundColor":"base-2","textColor":"contrast","className":"has-x-small-size","fontSize":"x-small"} /-->
 			<?php endif; ?>
 
 			<!-- wp:template-part {"slug":"mobile-menu","theme":"newspack-block-theme","tagName":"div","lock":{"move":false,"remove":true},"className":"mobile-menu"} /-->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the My Account Button block (with a conditional check) to all the header patterns bundled with the Newspack theme (excluding mobile layout 2 -- I just couldn't make it work nicely with the size of the button).

Open questions/comments:
* This is kind of an open question from the original PR, but the My Account Button looks the same on desktop or mobile - do we want to do anything special for mobile (like have a style that hides the text)?
* There is a weird couple-pixel mismatch in alignment in a couple of the mobile header layouts where the Donate Block is right next to the My Account button block. This is due to the icon -- in my testing, tweaking [this style](https://github.com/Automattic/newspack-block-theme/blob/821f81ceb53a396957e1bcbf5d1ab01e51d3ed1b/src/scss/blocks/_button.scss#L56-L57) to use `1.45em` as the smaller size fixed it, but I'm not sure if/how we'd want to do something like that (just target the x-small CSS class? Just target the editor? Leave it since the front-end is fine?) so I left it for now.

See NPPD-1177.

### How to test the changes in this Pull Request:

1. Apply the PR.
2. Navigate to the Site Editor > Patterns, and pick one of the Header patterns (Desktop or Mobile).
3. With the outer container selected, pick the Template Patterns tab on the right sidebar, and in the Design panel, go through the pattern options one by one to review in the editor, and then on the front-end. Confirm that the appearance/order/spacing/etc. makes sense:

**Desktop:**
Pattern 1:
<img width="1351" height="367" alt="CleanShot 2026-01-30 at 11 44 04" src="https://github.com/user-attachments/assets/65ebaeda-39ea-45a3-963e-e47fd0054707" />

Pattern 2:
<img width="1336" height="336" alt="CleanShot 2026-01-30 at 11 46 57" src="https://github.com/user-attachments/assets/1277eae3-d071-46ab-8761-48e50bc85b92" />

Pattern 3:
<img width="1303" height="280" alt="CleanShot 2026-01-30 at 11 50 51" src="https://github.com/user-attachments/assets/ece2de03-a720-4498-bd5e-0ec8f71b4b6d" />

Pattern 4:
<img width="1573" height="279" alt="CleanShot 2026-01-30 at 11 52 21" src="https://github.com/user-attachments/assets/6aed5866-604d-4c77-bce8-556ddb1372db" />

Pattern 5:
<img width="1324" height="370" alt="CleanShot 2026-01-30 at 11 54 14" src="https://github.com/user-attachments/assets/f9dc4266-95fd-49bd-a726-52ca4fe595a3" />

**Mobile:**
Pattern 1:
<img width="569" height="97" alt="CleanShot 2026-01-30 at 11 58 00" src="https://github.com/user-attachments/assets/425c9bb3-948d-40ad-a63a-2564a62e38ef" />

Pattern 3:
<img width="592" height="106" alt="CleanShot 2026-01-30 at 12 01 36" src="https://github.com/user-attachments/assets/fefdc6bd-79a0-4d5d-8893-77a1f5e56943" />

4. Review the code and confirm that each My Account button is wrapped in a check to make sure RAS is enabled.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
