### PR TITLE
fix: update single post template widths

### DIFF
--- a/templates/single.html
+++ b/templates/single.html
@@ -13,7 +13,7 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
-		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"wide","layout":{"type":"constrained"}} /-->
+		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/templates/single/50-50-image.html
+++ b/templates/single/50-50-image.html
@@ -21,7 +21,7 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
-		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"wide","layout":{"type":"constrained"}} /-->
+		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/templates/single/full-width-image.html
+++ b/templates/single/full-width-image.html
@@ -13,7 +13,7 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
-		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"wide","layout":{"type":"constrained"}} /-->
+		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/templates/single/large-image.html
+++ b/templates/single/large-image.html
@@ -13,7 +13,7 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
-		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"wide","layout":{"type":"constrained"}} /-->
+		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->
 

--- a/templates/single/wide-image.html
+++ b/templates/single/wide-image.html
@@ -13,7 +13,7 @@
 
 	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
-		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"wide","layout":{"type":"constrained"}} /-->
+		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
 	</div>
 	<!-- /wp:group -->
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR changes the post-content width in most Single templates from 'wide' to 'full'. I noticed when testing something else that the 'wide' template width was preventing full-width blocks from displaying that way in the editor (they did preview that way on the front-end though!). 

There are also a couple page templates with the same setup but with the layout type default instead of constrained - I think this is so the page content is automatically wide width without needing to change all the blocks to 'wide' but I might have that wrong!

### How to test the changes in this Pull Request:

1. Set up a single post and add a group block to the content. Set it to full width.
2. Note the block previews as wide in the editor, even though it does display as full-width on the front-end.
3. Apply this PR. 
4. Confirm that the full-width group block displays as full-width in the editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
