### PR TITLE
feat: allow parent to dictate position when it has the position class

### DIFF
--- a/.github/UTILITY_CLASSES.md
+++ b/.github/UTILITY_CLASSES.md
@@ -73,6 +73,8 @@ Additionally, `is-position-sticky--mobile-only` and `is-position-sticky--desktop
 
 The class `overlay-contents` needs to be applied along with a position class: `overlay-contents--position--left`, `overlay-contents--position--right`, or `overlay-contents--position--full-width`.
 
+When the overlay contents are included via a template-part (e.g. mobile menu), the **parent** template-part wrapper can set a position class (e.g. `overlay-contents--position--right` on the wrapper) to override the contents’ own position. That lets patterns control slide direction without editing the shared template part.
+
 When using the right or left position, you can also control the width, which defaults to a maximum of 632px.
 
 | CLASS NAME                             | DESCRIPTION                                                                |

--- a/.github/UTILITY_CLASSES.md
+++ b/.github/UTILITY_CLASSES.md
@@ -73,7 +73,7 @@ Additionally, `is-position-sticky--mobile-only` and `is-position-sticky--desktop
 
 The class `overlay-contents` needs to be applied along with a position class: `overlay-contents--position--left`, `overlay-contents--position--right`, or `overlay-contents--position--full-width`.
 
-When the overlay contents are included via a template-part (e.g. mobile menu), the **parent** template-part wrapper can set a position class (e.g. `overlay-contents--position--right` on the wrapper) to override the contents’ own position. That lets patterns control slide direction without editing the shared template part.
+When the overlay contents are included via a template-part (e.g. mobile menu), the **parent** template-part wrapper can set a **force** position class (e.g. `overlay-contents--position--right--force` on the wrapper) to override the contents’ own position in JavaScript, without changing editor/front-end CSS. This lets patterns control slide direction without editing the shared template part.
 
 When using the right or left position, you can also control the width, which defaults to a maximum of 632px.
 

--- a/.github/UTILITY_CLASSES.md
+++ b/.github/UTILITY_CLASSES.md
@@ -39,7 +39,7 @@ Note: The font size still needs to be changed to x-small if we're recreating a N
 `mobile-only` and `desktop-only` can be applied to blocks to display them based on the screen size.
 
 | CLASS NAME   | DESCRIPTION                                                                     |
-| -------------| ------------------------------------------------------------------------------- |
+| ------------ | ------------------------------------------------------------------------------- |
 | mobile-only  | The block will be displayed on the screen if it is 781px wide or less.          |
 | desktop-only | The block will be displayed on the screen if the screen is at least 782px wide. |
 
@@ -52,7 +52,7 @@ Adding `is-position-fixed` to a block will make it fixed at the top of the scree
 Additionally, `is-position-fixed--mobile-only` and `is-position-fixed--desktop-only` can be applied to blocks to fix their position based on the screen size.
 
 | CLASS NAME                      | DESCRIPTION                                                                 |
-| --------------------------------| --------------------------------------------------------------------------- |
+| ------------------------------- | --------------------------------------------------------------------------- |
 | is-position-fixed               | Class required to enable the fixed position.                                |
 | is-position-fixed--mobile-only  | The block will be fixed on the screen if it is 781px wide or less.          |
 | is-position-fixed--desktop-only | The block will be fixed on the screen if the screen is at least 782px wide. |
@@ -64,7 +64,7 @@ Adding `is-position-sticky` to a block will ensure it stays within the viewport 
 Additionally, `is-position-sticky--mobile-only` and `is-position-sticky--desktop-only` can be applied to blocks to make them sticky based on the screen size.
 
 | CLASS NAME                       | DESCRIPTION                                                                  |
-| ---------------------------------| ---------------------------------------------------------------------------- |
+| -------------------------------- | ---------------------------------------------------------------------------- |
 | is-position-sticky               | Class required to enable the sticky position.                                |
 | is-position-sticky--mobile-only  | The block will be sticky on the screen if it is 781px wide or less.          |
 | is-position-sticky--desktop-only | The block will be sticky on the screen if the screen is at least 782px wide. |
@@ -75,15 +75,19 @@ The class `overlay-contents` needs to be applied along with a position class: `o
 
 When the overlay contents are included via a template-part (e.g. mobile menu), the **parent** template-part wrapper can set a **force** position class (e.g. `overlay-contents--position--right--force` on the wrapper) to override the contents’ own position in JavaScript, without changing editor/front-end CSS. This lets patterns control slide direction without editing the shared template part.
 
-When using the right or left position, you can also control the width, which defaults to a maximum of 632px.
+When using the right or left position, you can also control the width; by default it uses `overlay-contents--width--medium`, where the content will expand to a maximum of 632px.
 
-| CLASS NAME                             | DESCRIPTION                                                                |
-| -------------------------------------- | -------------------------------------------------------------------------- |
-| overlay-contents                       | Class required to enable the overlay.                                      |
-| overlay-contents--position--left       | This is the default behavior, where the content will appear from the left. |
-| overlay-contents--position--right      | In this case, the content will slide in from the right.                    |
-| overlay-contents--position--full-width | The content will take over the full screen.                                |
-| overlay-contents--width--x-small       | The content will expand to a maximum of 300px.                             |
-| overlay-contents--width--small         | The content will expand to a maximum of 410px.                             |
-| overlay-contents--width--large         | The content will expand to a maximum of 964px.                             |
-| overlay-contents--width--x-large       | The content will expand to a maximum of 1296px.                            |
+| CLASS NAME                                    | DESCRIPTION                                                                                |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| overlay-contents                              | Class required to enable the overlay.                                                      |
+| overlay-contents--position--left              | This is the default behavior, where the content will appear from the left.                 |
+| overlay-contents--position--right             | In this case, the content will slide in from the right.                                    |
+| overlay-contents--position--full-width        | The content will take over the full screen.                                                |
+| overlay-contents--position--left--force       | Use on the parent template-part wrapper to force the content to slide in from the left.    |
+| overlay-contents--position--right--force      | Use on the parent template-part wrapper to force the content to slide in from the right.   |
+| overlay-contents--position--full-width--force | Use on the parent template-part wrapper to force the content to take over the full screen. |
+| overlay-contents--width--x-small              | The content will expand to a maximum of 300px.                                             |
+| overlay-contents--width--small                | The content will expand to a maximum of 410px.                                             |
+| overlay-contents--width--medium               | The content will expand to a maximum of 632px.                                             |
+| overlay-contents--width--large                | The content will expand to a maximum of 964px.                                             |
+| overlay-contents--width--x-large              | The content will expand to a maximum of 1296px.                                            |

--- a/parts/search-contents.html
+++ b/parts/search-contents.html
@@ -1,3 +1,5 @@
-<!-- wp:group {"templateLock":"all","lock":{"move":true,"remove":true},"metadata":{"name":"Content"},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:search {"buttonText":"Search","lock":{"move":true,"remove":true},"fontSize":"small"} /--></div>
+<!-- wp:group {"templateLock":"all","lock":{"move":true,"remove":true},"metadata":{"name":"Search Contents"},"style":{"spacing":{"padding":{"right":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-right:0;padding-left:0">
+	<!-- wp:search {"buttonText":"Search","lock":{"move":true,"remove":true},"fontSize":"small"} /-->
+</div>
 <!-- /wp:group -->

--- a/src/js/front-end/menus/index.js
+++ b/src/js/front-end/menus/index.js
@@ -762,27 +762,32 @@ export const createMenu = config => {
 					closeAllMenus();
 					onClose( contents, container, toggles );
 				} else {
-					openMenu();
+					// Resolve container and contents for the clicked toggle (e.g. search menu exists in both desktop and mobile header).
+					const containerForToggle = event.currentTarget.closest( containerSelector );
+					const contentsForToggle = containerForToggle?.querySelector( contentsSelector );
+					if ( containerForToggle && contentsForToggle ) {
+						openMenu( contentsForToggle, containerForToggle );
+					}
 				}
 			};
 
 			// Opens the menu and applies necessary styling.
-			const openMenu = () => {
+			const openMenu = ( contentsToOpen, containerToUse ) => {
 				body.classList.add( openClassName );
-				contents.classList.add( openClassName );
-				moveMenuToRoot( contents, menuType );
+				contentsToOpen.classList.add( openClassName );
+				moveMenuToRoot( contentsToOpen, menuType );
 
 				// Only show overlay for non-full-width menus
-				if ( ! isEffectiveFullWidthMenu( contents, slideAnimationManager ) ) {
+				if ( ! isEffectiveFullWidthMenu( contentsToOpen, slideAnimationManager ) ) {
 					overlayManager.show( overlayAnimationDuration );
 				}
 
 				// Handle onOpen callback or default behavior.
 				if ( onOpen ) {
-					onOpen( contents, container, toggles );
+					onOpen( contentsToOpen, containerToUse, toggles );
 				} else {
 					// Default behavior: focus the close button.
-					const closeButton = getMenuCloseButton( menuType, contents );
+					const closeButton = getMenuCloseButton( menuType, contentsToOpen );
 					if ( closeButton ) {
 						closeButton.focus();
 					}

--- a/src/js/front-end/menus/index.js
+++ b/src/js/front-end/menus/index.js
@@ -262,12 +262,19 @@ const createSlideAnimationManager = () => {
 		},
 	];
 
-	const getConfigForNode = node => {
+	const getConfigForNode = ( node, { allowForce = false } = {} ) => {
 		if ( ! node || ! node.classList ) {
 			return null;
 		}
 		for ( const config of slideConfigs ) {
-			if ( node.classList.contains( OVERLAY_POSITION_CLASS_PREFIX + config.direction ) ) {
+			const baseClass = OVERLAY_POSITION_CLASS_PREFIX + config.direction;
+			const forceClass = `${ baseClass }--force`;
+
+			if ( allowForce ) {
+				if ( node.classList.contains( forceClass ) ) {
+					return config;
+				}
+			} else if ( node.classList.contains( baseClass ) ) {
 				return config;
 			}
 		}
@@ -276,10 +283,15 @@ const createSlideAnimationManager = () => {
 
 	// Resolves slide params from DOM (element + parent). Call before moving element to body.
 	const resolveSlideParams = element => {
-		const parentConfig = element.parentElement ? getConfigForNode( element.parentElement ) : null;
-		if ( parentConfig ) {
-			return parentConfig;
+		const parent = element.parentElement;
+		if ( parent ) {
+			// Parent can override using force classes, e.g. overlay-contents--position--right--force.
+			const parentConfig = getConfigForNode( parent, { allowForce: true } );
+			if ( parentConfig ) {
+				return parentConfig;
+			}
 		}
+		// Fall back to the element's own position classes (no force).
 		return getConfigForNode( element );
 	};
 

--- a/src/js/front-end/menus/index.js
+++ b/src/js/front-end/menus/index.js
@@ -622,6 +622,47 @@ const moveMenuToRoot = ( menuElement, menuType ) => {
 };
 
 /**
+ * Runs slide-out animation and restores one menu contents element to its original DOM position.
+ *
+ * @param {HTMLElement} element The menu contents element to restore.
+ */
+const restoreMenuContent = element => {
+	// Clean up focus trap immediately
+	const cleanup = focusTrapCleanups.get( element );
+	if ( cleanup ) {
+		cleanup();
+	}
+
+	// Get original position
+	const originalPosition = menuPositions.get( element );
+	if ( ! originalPosition ) {
+		return;
+	}
+
+	// For full-width menus, delay class removal until after animation
+	const elementIsFullWidth = isEffectiveFullWidthMenu( element, slideAnimationManager );
+
+	// Start slide-out animation
+	slideAnimationManager.slideOut( element, ANIMATION_DURATION.OPACITY, ANIMATION_DURATION.POSITION, () => {
+		// Remove menu-open class from full-width elements after animation
+		if ( elementIsFullWidth ) {
+			removeClassesWithPrefix( element, MENU_OPEN_CLASS_NAME );
+		}
+
+		// Remove full-width class if we added it for parent override
+		if ( fullWidthClassAddedByUs.has( element ) ) {
+			element.classList.remove( OVERLAY_POSITION_CLASS_PREFIX + 'full-width' );
+			fullWidthClassAddedByUs.delete( element );
+		}
+
+		// Restore position after slide-out animation
+		restoreElementPosition( element, originalPosition );
+		menuPositions.delete( element );
+		slideAnimationManager.clearSlideParamsCache( element );
+	} );
+};
+
+/**
  * Closes all open menus.
  */
 export const closeAllMenus = () => {
@@ -643,42 +684,7 @@ export const closeAllMenus = () => {
 	} );
 	removeClassesWithPrefix( document.body, MENU_OPEN_CLASS_NAME );
 
-	// Handle menu contents restoration - simplified approach
-	menuContents.forEach( element => {
-		// Clean up focus trap immediately
-		const cleanup = focusTrapCleanups.get( element );
-		if ( cleanup ) {
-			cleanup();
-		}
-
-		// Get original position
-		const originalPosition = menuPositions.get( element );
-		if ( ! originalPosition ) {
-			return;
-		}
-
-		// For full-width menus, delay class removal until after animation
-		const elementIsFullWidth = isEffectiveFullWidthMenu( element, slideAnimationManager );
-
-		// Start slide-out animation
-		slideAnimationManager.slideOut( element, ANIMATION_DURATION.OPACITY, ANIMATION_DURATION.POSITION, () => {
-			// Remove menu-open class from full-width elements after animation
-			if ( elementIsFullWidth ) {
-				removeClassesWithPrefix( element, MENU_OPEN_CLASS_NAME );
-			}
-
-			// Remove full-width class if we added it for parent override
-			if ( fullWidthClassAddedByUs.has( element ) ) {
-				element.classList.remove( OVERLAY_POSITION_CLASS_PREFIX + 'full-width' );
-				fullWidthClassAddedByUs.delete( element );
-			}
-
-			// Restore position after slide-out animation
-			restoreElementPosition( element, originalPosition );
-			menuPositions.delete( element );
-			slideAnimationManager.clearSlideParamsCache( element );
-		} );
-	} );
+	menuContents.forEach( restoreMenuContent );
 
 	// Restore focus immediately
 	if ( lastFocusedElement ) {

--- a/src/js/front-end/menus/index.js
+++ b/src/js/front-end/menus/index.js
@@ -11,6 +11,9 @@ const menuPositions = new WeakMap();
 // Stores cleanup functions for active focus traps.
 const focusTrapCleanups = new WeakMap();
 
+// Elements we added overlay-contents--position--full-width to (parent override); remove class on restore.
+const fullWidthClassAddedByUs = new WeakSet();
+
 // Stores the last focused element before a menu was opened.
 let lastFocusedElement;
 
@@ -53,13 +56,22 @@ const removeClassesWithPrefix = ( element, prefix ) => {
 };
 
 /**
- * Helper function to check if an element is a full-width menu.
+ * Helper function to check if an element is effectively a full-width menu.
+ * Uses cached slide params (parent override) when available, otherwise the element's own class.
  *
- * @param {HTMLElement} element The element to check.
+ * @param {HTMLElement} element                  The element to check.
+ * @param {Object}      slideAnimationManagerRef Reference to the slide animation manager (used after it is created).
  * @return {boolean} True if element is a full-width menu, false otherwise.
  */
-const isFullWidthMenu = element => {
-	return element && element.classList.contains( OVERLAY_POSITION_CLASS_PREFIX + 'full-width' );
+const isEffectiveFullWidthMenu = ( element, slideAnimationManagerRef ) => {
+	if ( ! element ) {
+		return false;
+	}
+	const params = slideAnimationManagerRef?.getSlideParams( element );
+	if ( params ) {
+		return params.direction === 'full-width';
+	}
+	return element.classList.contains( OVERLAY_POSITION_CLASS_PREFIX + 'full-width' );
 };
 
 /**
@@ -226,36 +238,71 @@ const createSlideAnimationManager = () => {
 	// Store slide animation cleanup functions.
 	const slideCleanups = new WeakMap();
 
-	// Determines slide direction and distance based on position class.
-	const getSlideParams = element => {
-		const slideConfigs = [
-			{
-				direction: 'left',
-				property: 'left',
-				hiddenValue: POSITION_VALUES.HIDDEN,
-				visibleValue: POSITION_VALUES.VISIBLE,
-			},
-			{
-				direction: 'right',
-				property: 'right',
-				hiddenValue: POSITION_VALUES.HIDDEN,
-				visibleValue: POSITION_VALUES.VISIBLE,
-			},
-			{
-				direction: 'full-width',
-				property: 'transform',
-				hiddenValue: POSITION_VALUES.TRANSFORM_HIDDEN,
-				visibleValue: POSITION_VALUES.TRANSFORM_VISIBLE,
-			},
-		];
+	// Cached slide params per element. Resolved before moving to body (when parent still has position class).
+	const slideParamsCache = new WeakMap();
 
+	const slideConfigs = [
+		{
+			direction: 'left',
+			property: 'left',
+			hiddenValue: POSITION_VALUES.HIDDEN,
+			visibleValue: POSITION_VALUES.VISIBLE,
+		},
+		{
+			direction: 'right',
+			property: 'right',
+			hiddenValue: POSITION_VALUES.HIDDEN,
+			visibleValue: POSITION_VALUES.VISIBLE,
+		},
+		{
+			direction: 'full-width',
+			property: 'transform',
+			hiddenValue: POSITION_VALUES.TRANSFORM_HIDDEN,
+			visibleValue: POSITION_VALUES.TRANSFORM_VISIBLE,
+		},
+	];
+
+	const getConfigForNode = node => {
+		if ( ! node || ! node.classList ) {
+			return null;
+		}
 		for ( const config of slideConfigs ) {
-			if ( element.classList.contains( OVERLAY_POSITION_CLASS_PREFIX + config.direction ) ) {
+			if ( node.classList.contains( OVERLAY_POSITION_CLASS_PREFIX + config.direction ) ) {
 				return config;
 			}
 		}
-
 		return null;
+	};
+
+	// Resolves slide params from DOM (element + parent). Call before moving element to body.
+	const resolveSlideParams = element => {
+		const parentConfig = element.parentElement ? getConfigForNode( element.parentElement ) : null;
+		if ( parentConfig ) {
+			return parentConfig;
+		}
+		return getConfigForNode( element );
+	};
+
+	// Determines slide direction and distance based on position class.
+	// Uses cache (set before move) so parent's position class is still available after element is moved to body.
+	const getSlideParams = element => {
+		const cached = slideParamsCache.get( element );
+		if ( cached ) {
+			return cached;
+		}
+		return resolveSlideParams( element );
+	};
+
+	// Call before moving element to body so parent's position class (e.g. overlay-contents--position--right) is used.
+	const cacheSlideParams = element => {
+		const params = resolveSlideParams( element );
+		if ( params ) {
+			slideParamsCache.set( element, params );
+		}
+	};
+
+	const clearSlideParamsCache = element => {
+		slideParamsCache.delete( element );
 	};
 
 	// Slides the menu content in from the specified direction.
@@ -275,6 +322,10 @@ const createSlideAnimationManager = () => {
 			existingCleanup();
 		}
 
+		// Set opposite position to auto so CSS from the element's position class (e.g. --left) doesn't give zero width when we animate the other side (e.g. right).
+		const oppositeProperty = slideParams.property === 'left' ? 'right' : 'left';
+		element.style[ oppositeProperty ] = 'auto';
+
 		// Set initial state.
 		element.style.opacity = '0';
 		element.style[ slideParams.property ] = slideParams.hiddenValue;
@@ -291,6 +342,7 @@ const createSlideAnimationManager = () => {
 		// Store cleanup function.
 		const cleanup = () => {
 			element.style.opacity = '';
+			element.style[ oppositeProperty ] = '';
 			element.style[ slideParams.property ] = '';
 			element.style.transition = '';
 			slideCleanups.delete( element );
@@ -317,6 +369,10 @@ const createSlideAnimationManager = () => {
 			return;
 		}
 
+		// Set opposite position to auto so element has correct width (avoids zero width when element has CSS --left but we animate --right).
+		const oppositeProperty = slideParams.property === 'left' ? 'right' : 'left';
+		element.style[ oppositeProperty ] = 'auto';
+
 		// Set transition for slide out.
 		element.style.transition = `opacity ${ opacityDuration }ms ease-in-out, ${ slideParams.property } ${ positionDuration }ms ease-in-out`;
 
@@ -342,7 +398,7 @@ const createSlideAnimationManager = () => {
 		slideCleanups.forEach( cleanupFn => cleanupFn() );
 	};
 
-	return { slideIn, slideOut, cleanup };
+	return { cacheSlideParams, clearSlideParamsCache, getSlideParams, slideIn, slideOut, cleanup };
 };
 
 /**
@@ -540,6 +596,15 @@ const moveMenuToRoot = ( menuElement, menuType ) => {
 		return;
 	}
 
+	// Resolve and cache slide params while element is still in DOM (parent may have position class).
+	slideAnimationManager.cacheSlideParams( menuElement );
+
+	const slideParams = slideAnimationManager.getSlideParams( menuElement );
+	if ( slideParams?.direction === 'full-width' && ! menuElement.classList.contains( OVERLAY_POSITION_CLASS_PREFIX + 'full-width' ) ) {
+		menuElement.classList.add( OVERLAY_POSITION_CLASS_PREFIX + 'full-width' );
+		fullWidthClassAddedByUs.add( menuElement );
+	}
+
 	// Store original position.
 	menuPositions.set( menuElement, {
 		parent: menuElement.parentNode,
@@ -572,7 +637,7 @@ export const closeAllMenus = () => {
 	// Remove menu-open classes immediately to allow toggle to work properly
 	// (except for full-width menus which need the class during slide-out animation)
 	openMenuElements.forEach( element => {
-		if ( ! isFullWidthMenu( element ) ) {
+		if ( ! isEffectiveFullWidthMenu( element, slideAnimationManager ) ) {
 			removeClassesWithPrefix( element, MENU_OPEN_CLASS_NAME );
 		}
 	} );
@@ -593,7 +658,7 @@ export const closeAllMenus = () => {
 		}
 
 		// For full-width menus, delay class removal until after animation
-		const elementIsFullWidth = isFullWidthMenu( element );
+		const elementIsFullWidth = isEffectiveFullWidthMenu( element, slideAnimationManager );
 
 		// Start slide-out animation
 		slideAnimationManager.slideOut( element, ANIMATION_DURATION.OPACITY, ANIMATION_DURATION.POSITION, () => {
@@ -602,9 +667,16 @@ export const closeAllMenus = () => {
 				removeClassesWithPrefix( element, MENU_OPEN_CLASS_NAME );
 			}
 
+			// Remove full-width class if we added it for parent override
+			if ( fullWidthClassAddedByUs.has( element ) ) {
+				element.classList.remove( OVERLAY_POSITION_CLASS_PREFIX + 'full-width' );
+				fullWidthClassAddedByUs.delete( element );
+			}
+
 			// Restore position after slide-out animation
 			restoreElementPosition( element, originalPosition );
 			menuPositions.delete( element );
+			slideAnimationManager.clearSlideParamsCache( element );
 		} );
 	} );
 
@@ -695,7 +767,7 @@ export const createMenu = config => {
 				moveMenuToRoot( contents, menuType );
 
 				// Only show overlay for non-full-width menus
-				if ( ! isFullWidthMenu( contents ) ) {
+				if ( ! isEffectiveFullWidthMenu( contents, slideAnimationManager ) ) {
 					overlayManager.show( overlayAnimationDuration );
 				}
 

--- a/src/scss/overlays/_base.scss
+++ b/src/scss/overlays/_base.scss
@@ -112,6 +112,14 @@
 		}
 	}
 
+	&--width--medium {
+		max-width: calc(var(--wp--preset--spacing--30) + var(--wp--style--global--content-size) + var(--wp--preset--spacing--30));
+
+		@include sass-utils.media(medium) {
+			max-width: calc(var(--wp--preset--spacing--40) + var(--wp--style--global--content-size) + var(--wp--preset--spacing--40));
+		}
+	}
+
 	&--width--large {
 		max-width: calc(var(--wp--preset--spacing--30) + var(--wp--custom--width--large) + var(--wp--preset--spacing--30));
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds support for parent containers to `--force` an overlay’s position.

Specifically, when overlay content is included via a template part, such as the mobile menu, the parent template part wrapper can define a position class like `overlay-contents--position--right--force`. This overrides the position set within the overlay itself, allowing patterns to control the slide direction without modifying the shared template part.

This allows us to have multiple patterns (e.g. header) but still make sure the overlay comes from the correct side of the screen based on how buttons are organised.

### How to test the changes in this Pull Request:

_Note: Small screen is probably the easiest way to test so resize your screen_

1. Open your homepage and open the mobile menu. Notice it appears from the left as defined in `parts/mobile-menu.html`
2. Switch to this branch
3. In the editor, open your Header (mobile) and add a class of `overlay-contents--position--right--force` to the `mobile-menu` part, save
4. Reload your homepage
5. Notice now the menu opens from the right.
6. Test this with `--ful-width--force` too
7. Test if the search overlay still works (there was a small bug with the padding and was opened twice)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
