### PR TITLE
refactor(author-profile): move social button styles to plugin

### DIFF
--- a/src/scss/blocks/newspack/_author-profile.scss
+++ b/src/scss/blocks/newspack/_author-profile.scss
@@ -74,51 +74,6 @@
 		}
 	}
 
-	&__social-links {
-		align-items: center;
-		display: flex;
-		flex-wrap: wrap;
-		font-size: var(--wp--preset--font-size--x-small);
-		gap: var(--wp--custom--spacing--10);
-		line-height: var(--wp--custom--line-height--x-small);
-		margin: var(--wp--preset--spacing--30) 0 0;
-		text-transform: uppercase;
-
-		li {
-			margin: 0;
-		}
-
-		a {
-			background: var(--wp--preset--color--base-2);
-			border-radius: var(--wp--custom--border--radius-small);
-			color: var(--wp--preset--color--contrast);
-			display: grid;
-			font-weight: 600;
-			min-height: var(--wp--preset--spacing--50);
-			padding: var(--wp--custom--spacing--10) var(--wp--preset--spacing--20);
-			place-items: center;
-			text-decoration: none;
-			transition:
-				background 125ms ease-in-out,
-				color 125ms ease-in-out,
-				outline 125ms ease-in-out;
-
-			&:hover {
-				background: var(--wp--preset--color--base-3);
-				text-decoration: none;
-			}
-
-			&:focus {
-				outline: none;
-			}
-
-			&:focus-visible {
-				outline: 2px solid;
-				outline-offset: 1px;
-			}
-		}
-	}
-
 	/* Block Styles */
 	@include sass-utils.media(small) {
 		&.avatar-right {
@@ -227,24 +182,6 @@
 
 			h3 {
 				color: inherit;
-			}
-		}
-	}
-}
-
-/* Has Background Color */
-.has-background {
-	.wp-block-newspack-blocks-author-profile {
-		&__social-links {
-			color: inherit;
-
-			a {
-				background: color-mix(in srgb, currentcolor 15%, transparent);
-				color: currentcolor;
-
-				&:hover {
-					background: color-mix(in srgb, currentcolor 20%, transparent);
-				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes the Author Profile social button styles from the theme. These styles are now provided by the social blocks themselves in newspack-plugin via a shared `socialButton` SCSS mixin, so they render consistently across all block themes without requiring theme-specific CSS.

Closes NPPD-1147.

Related PRs:
- https://github.com/Automattic/newspack-blocks/pull/2286
- https://github.com/Automattic/newspack-plugin/pull/4448

### How to test the changes in this Pull Request:

Requires the companion newspack-blocks and newspack-plugin branches.

1. Activate the block theme with all three companion branches.
2. View an Author Profile block with social links on the frontend.
3. Verify the social icons still have circular backgrounds with hover effects.
4. Verify there is no duplicate or conflicting styling from the theme.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?