### PR TITLE
Use dynamic copyright date block in footer patterns

### DIFF
--- a/patterns/footer/footer-desktop-style-1.php
+++ b/patterns/footer/footer-desktop-style-1.php
@@ -51,9 +51,7 @@
 			<div class="wp-block-group has-x-small-font-size" style="padding-bottom:var(--wp--preset--spacing--50)">
 				<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Copyright', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"0.25em"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph -->
-					<p><strong>©</strong></p>
-					<!-- /wp:paragraph -->
+					<!-- wp:newspack/copyright-date /-->
 
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
 				</div>

--- a/patterns/footer/footer-desktop-style-2.php
+++ b/patterns/footer/footer-desktop-style-2.php
@@ -59,9 +59,7 @@
 			<div class="wp-block-group has-x-small-font-size" style="padding-bottom:var(--wp--preset--spacing--50)">
 				<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Copyright', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"0.25em"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph -->
-					<p><strong>©</strong></p>
-					<!-- /wp:paragraph -->
+					<!-- wp:newspack/copyright-date /-->
 
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
 				</div>

--- a/patterns/footer/footer-desktop-style-3.php
+++ b/patterns/footer/footer-desktop-style-3.php
@@ -79,9 +79,7 @@
 			<div class="wp-block-group has-x-small-font-size" style="padding-bottom:var(--wp--preset--spacing--50)">
 				<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Copyright', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"0.25em"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph -->
-					<p><strong>©</strong></p>
-					<!-- /wp:paragraph -->
+					<!-- wp:newspack/copyright-date /-->
 
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
 				</div>

--- a/patterns/footer/footer-desktop-style-4.php
+++ b/patterns/footer/footer-desktop-style-4.php
@@ -78,9 +78,7 @@
 			<div class="wp-block-group has-x-small-font-size" style="padding-bottom:var(--wp--preset--spacing--50)">
 				<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Copyright', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"0.25em"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph -->
-					<p><strong>©</strong></p>
-					<!-- /wp:paragraph -->
+					<!-- wp:newspack/copyright-date /-->
 
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
 				</div>

--- a/patterns/footer/footer-desktop-style-5.php
+++ b/patterns/footer/footer-desktop-style-5.php
@@ -80,9 +80,7 @@
 			<div class="wp-block-group has-x-small-font-size" style="padding-bottom:var(--wp--preset--spacing--50)">
 				<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Copyright', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"0.25em"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph -->
-					<p><strong>©</strong></p>
-					<!-- /wp:paragraph -->
+					<!-- wp:newspack/copyright-date /-->
 
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
 				</div>

--- a/patterns/footer/footer-mobile-style-1.php
+++ b/patterns/footer/footer-mobile-style-1.php
@@ -52,9 +52,7 @@
 			<div class="wp-block-group has-x-small-font-size" style="padding-bottom:var(--wp--preset--spacing--30)">
 				<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"<?php esc_html_e( 'Copyright', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"0.25em"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 				<div class="wp-block-group">
-					<!-- wp:paragraph -->
-					<p><strong>©</strong></p>
-					<!-- /wp:paragraph -->
+					<!-- wp:newspack/copyright-date /-->
 
 					<!-- wp:site-title {"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"x-small"} /-->
 				</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replaces the static `© <year>` paragraph block in all 6 footer patterns with the new `newspack/copyright-date` dynamic block from newspack-plugin. The year now updates automatically based on the site's timezone instead of being hardcoded in the pattern markup.

Depends on Automattic/newspack-plugin#4494.

Closes NPPD-1186.

### How to test the changes in this Pull Request:

1. Ensure the newspack-plugin branch `feat/copyright-date-block` is active.
2. Create a new page and insert any of the footer patterns (Footer Desktop Style 1 through 5, or Footer Mobile Style 1).
3. Verify the copyright symbol and current year render in the footer area.
4. Check the frontend output and confirm the year is dynamic (wrapped in a `<span>` rather than a static paragraph).
5. Edit the copyright date block within the footer and confirm the prefix/suffix fields work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?