### PR TITLE
feat(patterns): use author profile block in author bio patterns

### DIFF
--- a/patterns/author-bio/author-bio-avatar.php
+++ b/patterns/author-bio/author-bio-avatar.php
@@ -5,11 +5,12 @@
  * Categories: newspack-block-theme-author-bio
  * Viewport Width: 632
  * Inserter: yes
- * Block Types: core/avatar, core/post-author-name, core/post-author-biography
+ * Block Types: newspack-blocks/author-profile, core/avatar, core/post-author-name, core/post-author-biography
  *
  * @package Newspack_Block_Theme
  */
 
+$registry = WP_Block_Type_Registry::get_instance();
 ?>
 <!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Author Bio', 'newspack-block-theme' ); ?>"},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 <div class="wp-block-group">
@@ -17,6 +18,12 @@
 	<!-- wp:separator {"className":"is-style-wide"} -->
 	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
 	<!-- /wp:separator -->
+
+<?php if ( $registry->get_registered( 'newspack-blocks/author-profile' ) ) : ?>
+
+	<!-- wp:newspack-blocks/author-profile {"isContextual":true,"layoutVersion":2,"variation":"avatar-left"} /-->
+
+<?php else : ?>
 
 	<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group">
@@ -29,6 +36,8 @@
 
 	</div>
 	<!-- /wp:group -->
+
+<?php endif; ?>
 
 	<!-- wp:separator {"className":"is-style-wide"} -->
 	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>

--- a/patterns/author-bio/author-bio.php
+++ b/patterns/author-bio/author-bio.php
@@ -5,11 +5,12 @@
  * Categories: newspack-block-theme-author-bio
  * Viewport Width: 632
  * Inserter: yes
- * Block Types: core/post-author-name, core/post-author-biography
+ * Block Types: newspack-blocks/author-profile, core/post-author-name, core/post-author-biography
  *
  * @package Newspack_Block_Theme
  */
 
+$registry = WP_Block_Type_Registry::get_instance();
 ?>
 <!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Author Bio', 'newspack-block-theme' ); ?>"},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
 <div class="wp-block-group">
@@ -17,6 +18,12 @@
 	<!-- wp:separator {"className":"is-style-wide"} -->
 	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
 	<!-- /wp:separator -->
+
+<?php if ( $registry->get_registered( 'newspack-blocks/author-profile' ) ) : ?>
+
+	<!-- wp:newspack-blocks/author-profile {"isContextual":true,"layoutVersion":2,"variation":"compact"} /-->
+
+<?php else : ?>
 
 	<!-- wp:group {"metadata":{"name":"<?php esc_html_e( 'Content', 'newspack-block-theme' ); ?>"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group">
@@ -27,6 +34,8 @@
 
 	</div>
 	<!-- /wp:group -->
+
+<?php endif; ?>
 
 	<!-- wp:separator {"className":"is-style-wide"} -->
 	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updates the author bio patterns (`author-bio` and `author-bio-avatar`) to use the Author Profile block with layout variations when `newspack-blocks` is available. The patterns set only the `variation` attribute (`avatar-left` or `compact`) and rely on the block's JS auto-populate logic to fill inner blocks from the variation template, keeping pattern markup minimal. Falls back to the existing core blocks (avatar, post-author-name, post-author-biography) when the Author Profile block is not registered.

Closes NPPD-1221.

---
**Feedback required:** Since `newspack-blocks` is always expected to be active on Newspack sites, is the PHP fallback to core blocks necessary? Two options to consider:
1. Drop the PHP conditional and make the patterns pure HTML with just the Author Profile block reference.
2. Drop the patterns entirely and inline the Author Profile block directly in `parts/post-footer.html`, since the patterns are essentially thin wrappers (separators + the block) at this point.
---

### How to test the changes in this Pull Request:

1. Activate the block theme with `newspack-blocks` active.
2. Go to Appearance > Editor > Templates > Single Posts.
3. Open the block inserter, go to Patterns tab, select "Newspack Theme - Author Bio" category.
4. Insert "Author Bio with Avatar" and verify it auto-populates the `avatar-left` variation with all fields (name, job title, role, employer, bio, archive link, social links) in a two-column layout.
5. Insert "Author Bio" and verify it auto-populates the `compact` variation with all fields in a vertical stack layout.
6. Select each inserted Author Profile block and confirm the block attributes include `variation: "avatar-left"` or `variation: "compact"`, `layoutVersion: 2`, and `isContextual: true`.
7. Open a post in the post editor, insert both patterns, and verify author data populates from the post's actual author.
8. View the post on the frontend and verify the author profile renders correctly.
9. Deactivate `newspack-blocks` and verify the patterns fall back to core blocks (avatar, post-author-name, post-author-biography).
10. Verify the Post Footer template part still works correctly since it references `newspack-block-theme/author-bio` via `wp:pattern`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?