### PR TITLE
fix: update subtitle block for compatibility with iframed Post Editor

### DIFF
--- a/includes/blocks/subtitle-block/block.json
+++ b/includes/blocks/subtitle-block/block.json
@@ -4,6 +4,7 @@
 	"name": "newspack-block-theme/article-subtitle",
 	"title": "Article Subtitle",
 	"category": "newspack",
+	"usesContext": [ "postId", "postType" ],
 	"attributes": {},
 	"supports": {
 		"html": false,

--- a/includes/blocks/subtitle-block/block.json
+++ b/includes/blocks/subtitle-block/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-block-theme/article-subtitle",
 	"title": "Article Subtitle",
 	"category": "newspack",

--- a/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -52,7 +52,7 @@ final class Subtitle_Block {
 	public static function render_block() {
 		$post_subtitle = get_post_meta( get_the_ID(), self::POST_META_NAME, true );
 		$wrapper_attributes = get_block_wrapper_attributes();
-		return sprintf( '<p %1$s>%2$s</p>', $wrapper_attributes, $post_subtitle );
+		return sprintf( '<p %1$s>%2$s</p>', $wrapper_attributes, esc_html( $post_subtitle ) );
 	}
 
 	/**

--- a/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -70,11 +70,13 @@ final class Subtitle_Block {
 		global $pagenow;
 		if ( $pagenow === 'site-editor.php' ) {
 			$handle = 'newspack-block-theme-subtitle-block-site-editor';
-			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-site-editor.js' ), [ 'wp-block-editor' ], NEWSPACK_BLOCK_THEME_VERSION, true );
+			$asset  = require \get_theme_file_path( 'dist/subtitle-block-site-editor.asset.php' );
+			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-site-editor.js' ), $asset['dependencies'], $asset['version'], true );
 			\wp_localize_script( $handle, 'newspack_block_theme_subtitle_block', $script_data );
 		} elseif ( \get_current_screen() && \get_current_screen()->post_type === 'post' ) {
 			$handle = 'newspack-block-theme-subtitle-block-post-editor';
-			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-post-editor.js' ), [], NEWSPACK_BLOCK_THEME_VERSION, true );
+			$asset  = require \get_theme_file_path( 'dist/subtitle-block-post-editor.asset.php' );
+			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-post-editor.js' ), $asset['dependencies'], $asset['version'], true );
 			\wp_localize_script( $handle, 'newspack_block_theme_subtitle_block', $script_data );
 		}
 	}

--- a/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -21,7 +21,7 @@ final class Subtitle_Block {
 	 */
 	public static function init() {
 		\add_action( 'init', [ __CLASS__, 'register_block_and_post_meta' ] );
-		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
 	}
 
 	/**
@@ -29,7 +29,7 @@ final class Subtitle_Block {
 	 */
 	public static function register_block_and_post_meta() {
 		register_block_type_from_metadata(
-			__DIR__ . '/block.json',
+			__DIR__,
 			[
 				'render_callback' => [ __CLASS__, 'render_block' ],
 			]
@@ -56,10 +56,13 @@ final class Subtitle_Block {
 	}
 
 	/**
-	 * Enqueue block editor ad suppression assets for any post type considered
-	 * "viewable".
+	 * Enqueue block editor subtitle assets for the appropriate editor context.
 	 */
-	public static function enqueue_block_editor_assets() {
+	public static function enqueue_block_assets() {
+		if ( ! \wp_should_load_block_editor_scripts_and_styles() ) {
+			return;
+		}
+
 		$script_data = [
 			'post_meta_name' => self::POST_META_NAME,
 		];
@@ -67,7 +70,7 @@ final class Subtitle_Block {
 		global $pagenow;
 		if ( $pagenow === 'site-editor.php' ) {
 			$handle = 'newspack-block-theme-subtitle-block-site-editor';
-			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-site-editor.js' ), [], NEWSPACK_BLOCK_THEME_VERSION, true );
+			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-site-editor.js' ), [ 'wp-block-editor' ], NEWSPACK_BLOCK_THEME_VERSION, true );
 			\wp_localize_script( $handle, 'newspack_block_theme_subtitle_block', $script_data );
 		}
 

--- a/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -72,7 +72,7 @@ final class Subtitle_Block {
 			$handle = 'newspack-block-theme-subtitle-block-site-editor';
 			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-site-editor.js' ), [ 'wp-block-editor' ], NEWSPACK_BLOCK_THEME_VERSION, true );
 			\wp_localize_script( $handle, 'newspack_block_theme_subtitle_block', $script_data );
-		} elseif ( \get_current_screen()->post_type === 'post' ) {
+		} elseif ( \get_current_screen() && \get_current_screen()->post_type === 'post' ) {
 			$handle = 'newspack-block-theme-subtitle-block-post-editor';
 			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-post-editor.js' ), [], NEWSPACK_BLOCK_THEME_VERSION, true );
 			\wp_localize_script( $handle, 'newspack_block_theme_subtitle_block', $script_data );

--- a/includes/blocks/subtitle-block/class-subtitle-block.php
+++ b/includes/blocks/subtitle-block/class-subtitle-block.php
@@ -72,10 +72,7 @@ final class Subtitle_Block {
 			$handle = 'newspack-block-theme-subtitle-block-site-editor';
 			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-site-editor.js' ), [ 'wp-block-editor' ], NEWSPACK_BLOCK_THEME_VERSION, true );
 			\wp_localize_script( $handle, 'newspack_block_theme_subtitle_block', $script_data );
-		}
-
-		$post_type = \get_current_screen()->post_type;
-		if ( $post_type === 'post' ) {
+		} elseif ( \get_current_screen()->post_type === 'post' ) {
 			$handle = 'newspack-block-theme-subtitle-block-post-editor';
 			\wp_enqueue_script( $handle, \get_theme_file_uri( 'dist/subtitle-block-post-editor.js' ), [], NEWSPACK_BLOCK_THEME_VERSION, true );
 			\wp_localize_script( $handle, 'newspack_block_theme_subtitle_block', $script_data );

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -115,8 +115,9 @@ const NewspackSubtitlePanel = () => {
 	useEffect( () => {
 		const editorDoc = getEditorCanvas();
 		const subtitleEl = editorDoc.getElementById( SUBTITLE_ID );
-		if ( subtitleEl && subtitleEl.textContent !== subtitle ) {
-			subtitleEl.textContent = subtitle;
+		const subtitleText = typeof subtitle === 'string' ? subtitle : '';
+		if ( subtitleEl && subtitleEl.textContent !== subtitleText ) {
+			subtitleEl.textContent = subtitleText;
 		}
 	}, [ subtitle ] );
 };

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -84,10 +84,9 @@ const NewspackSubtitlePanel = () => {
 		},
 		[ editPost ]
 	);
-	// Track timeout with a ref so we can find it for cleanup.
+	// Mount effect: poll for canvas, then create element.
 	const timeoutRef = useRef();
 	useEffect( () => {
-		// Retry until the editor canvas (potentially inside an iframe) is ready.
 		let retryCount = 0;
 		const maxRetries = 50; // 5 seconds at 100ms intervals.
 		const tryAppend = () => {
@@ -104,7 +103,17 @@ const NewspackSubtitlePanel = () => {
 		return () => {
 			clearTimeout( timeoutRef.current );
 		};
-	}, [ subtitle, saveSubtitle ] );
+	}, [] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	// Sync effect: update element when subtitle changes.
+	// Extracted from appendSubtitleToTitleDOMElement() above.
+	useEffect( () => {
+		const editorDoc = getEditorCanvas();
+		const subtitleEl = editorDoc.getElementById( SUBTITLE_ID );
+		if ( subtitleEl && subtitleEl.textContent !== subtitle ) {
+			subtitleEl.textContent = subtitle;
+		}
+	}, [ subtitle ] );
 };
 
 registerPlugin( 'plugin-document-setting-panel-newspack-subtitle', {

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -54,15 +54,15 @@ const appendSubtitleToTitleDOMElement = ( subtitle, editorDoc, callback ) => {
 			subtitleEl = editorDoc.createElement( 'div' );
 			subtitleEl.setAttribute( 'contenteditable', 'plaintext-only' );
 			subtitleEl.addEventListener( 'input', () => {
-				callback( subtitleEl.innerHTML );
+				callback( subtitleEl.textContent );
 			} );
 			subtitleEl.id = SUBTITLE_ID;
 			titleParent.insertBefore( subtitleEl, titleWrapperEl.nextSibling );
 		}
-		// Only update innerHTML if it differs, to avoid frustrating fast
+		// Only update textContent if it differs, to avoid frustrating fast
 		// typists.
-		if ( subtitleEl.innerHTML !== subtitle ) {
-			subtitleEl.innerHTML = subtitle;
+		if ( subtitleEl.textContent !== subtitle ) {
+			subtitleEl.textContent = subtitle;
 		}
 	}
 };

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -29,7 +29,7 @@ const getEditorCanvas = () => {
 const appendSubtitleToTitleDOMElement = ( subtitle, editorDoc, callback ) => {
 	const titleWrapperEl = editorDoc.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
 
-	if ( titleWrapperEl && typeof subtitle === 'string' ) {
+	if ( titleWrapperEl ) {
 		let subtitleEl = editorDoc.getElementById( SUBTITLE_ID );
 		const titleParent = titleWrapperEl.parentNode;
 
@@ -60,8 +60,9 @@ const appendSubtitleToTitleDOMElement = ( subtitle, editorDoc, callback ) => {
 			titleParent.insertBefore( subtitleEl, titleWrapperEl.nextSibling );
 		}
 		// Only update textContent if it differs, to avoid frustrating fast typists.
-		if ( subtitleEl.textContent !== subtitle ) {
-			subtitleEl.textContent = subtitle;
+		const subtitleText = subtitle ?? '';
+		if ( subtitleEl.textContent !== subtitleText ) {
+			subtitleEl.textContent = subtitleText;
 		}
 	}
 };

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -26,8 +26,7 @@ const getEditorCanvas = () => {
 	return document;
 };
 
-const appendSubtitleToTitleDOMElement = ( subtitle, callback ) => {
-	const editorDoc = getEditorCanvas();
+const appendSubtitleToTitleDOMElement = ( subtitle, editorDoc, callback ) => {
 	const titleWrapperEl = editorDoc.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
 
 	if ( titleWrapperEl && typeof subtitle === 'string' ) {
@@ -96,7 +95,7 @@ const NewspackSubtitlePanel = () => {
 			const editorDoc = getEditorCanvas();
 			const titleWrapperEl = editorDoc.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
 			if ( titleWrapperEl ) {
-				appendSubtitleToTitleDOMElement( subtitle, saveSubtitle );
+				appendSubtitleToTitleDOMElement( subtitle, editorDoc, saveSubtitle );
 			} else if ( retryCount < maxRetries ) {
 				retryCount++;
 				timeoutRef.current = setTimeout( tryAppend, 100 );

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -13,15 +13,30 @@ const META_FIELD_NAME = newspack_block_theme_subtitle_block.post_meta_name;
 const SUBTITLE_ID = 'newspack-post-subtitle-element';
 const SUBTITLE_STYLE_ID = 'newspack-post-subtitle-element-style';
 
+/**
+ * Get the correct document for the editor canvas.
+ * In iframe mode, the editor content is inside an iframe with name="editor-canvas".
+ * In non-iframe mode, falls back to the admin document.
+ */
+const getEditorCanvas = () => {
+	const iframe = document.querySelector( 'iframe[name="editor-canvas"]' );
+	if ( iframe?.contentDocument ) {
+		return iframe.contentDocument;
+	}
+	return document;
+};
+
 const appendSubtitleToTitleDOMElement = ( subtitle, callback ) => {
-	const titleWrapperEl = document.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
+	const editorDoc = getEditorCanvas();
+	const titleWrapperEl = editorDoc.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
 
 	if ( titleWrapperEl && typeof subtitle === 'string' ) {
-		let subtitleEl = document.getElementById( SUBTITLE_ID );
+		let subtitleEl = editorDoc.getElementById( SUBTITLE_ID );
 		const titleParent = titleWrapperEl.parentNode;
 
-		if ( ! document.getElementById( SUBTITLE_STYLE_ID ) ) {
-			const style = document.createElement( 'style' );
+		if ( ! editorDoc.getElementById( SUBTITLE_STYLE_ID ) ) {
+			const style = editorDoc.createElement( 'style' );
+			style.id = SUBTITLE_STYLE_ID;
 			style.innerHTML = `
                 #${ SUBTITLE_ID } {
                     font-style: italic;
@@ -33,11 +48,11 @@ const appendSubtitleToTitleDOMElement = ( subtitle, callback ) => {
                     padding-right: var(--wp--preset--spacing--30);
                 }
             `;
-			document.head.appendChild( style );
+			editorDoc.head.appendChild( style );
 		}
 
 		if ( ! subtitleEl ) {
-			subtitleEl = document.createElement( 'div' );
+			subtitleEl = editorDoc.createElement( 'div' );
 			subtitleEl.setAttribute( 'contenteditable', 'plaintext-only' );
 			subtitleEl.addEventListener( 'input', () => {
 				callback( subtitleEl.innerHTML );
@@ -65,7 +80,20 @@ const NewspackSubtitlePanel = () => {
 		} );
 	};
 	useEffect( () => {
-		appendSubtitleToTitleDOMElement( subtitle, saveSubtitle );
+		// Retry until the editor canvas (potentially inside an iframe) is ready.
+		let retryCount = 0;
+		const maxRetries = 50; // 5 seconds at 100ms intervals.
+		const tryAppend = () => {
+			const editorDoc = getEditorCanvas();
+			const titleWrapperEl = editorDoc.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
+			if ( titleWrapperEl ) {
+				appendSubtitleToTitleDOMElement( subtitle, saveSubtitle );
+			} else if ( retryCount < maxRetries ) {
+				retryCount++;
+				setTimeout( tryAppend, 100 );
+			}
+		};
+		tryAppend();
 	}, [] );
 };
 

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -6,7 +6,7 @@
  */
 import { registerPlugin } from '@wordpress/plugins';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useCallback, useRef } from '@wordpress/element';
 
 const META_FIELD_NAME = newspack_block_theme_subtitle_block.post_meta_name;
 
@@ -60,7 +60,11 @@ const appendSubtitleToTitleDOMElement = ( subtitle, callback ) => {
 			subtitleEl.id = SUBTITLE_ID;
 			titleParent.insertBefore( subtitleEl, titleWrapperEl.nextSibling );
 		}
-		subtitleEl.innerHTML = subtitle;
+		// Only update innerHTML if it differs, to avoid frustrating fast
+		// typists.
+		if ( subtitleEl.innerHTML !== subtitle ) {
+			subtitleEl.innerHTML = subtitle;
+		}
 	}
 };
 
@@ -71,14 +75,19 @@ const appendSubtitleToTitleDOMElement = ( subtitle, callback ) => {
  */
 const NewspackSubtitlePanel = () => {
 	const subtitle = useSelect( select => select( 'core/editor' ).getEditedPostAttribute( 'meta' )[ META_FIELD_NAME ] );
-	const dispatch = useDispatch();
-	const saveSubtitle = updatedSubtitle => {
-		dispatch( 'core/editor' ).editPost( {
-			meta: {
-				[ META_FIELD_NAME ]: updatedSubtitle,
-			},
-		} );
-	};
+	const { editPost } = useDispatch( 'core/editor' );
+	const saveSubtitle = useCallback(
+		updatedSubtitle => {
+			editPost( {
+				meta: {
+					[ META_FIELD_NAME ]: updatedSubtitle,
+				},
+			} );
+		},
+		[ editPost ]
+	);
+	// Track timeout with a ref so we can find it for cleanup.
+	const timeoutRef = useRef();
 	useEffect( () => {
 		// Retry until the editor canvas (potentially inside an iframe) is ready.
 		let retryCount = 0;
@@ -90,11 +99,14 @@ const NewspackSubtitlePanel = () => {
 				appendSubtitleToTitleDOMElement( subtitle, saveSubtitle );
 			} else if ( retryCount < maxRetries ) {
 				retryCount++;
-				setTimeout( tryAppend, 100 );
+				timeoutRef.current = setTimeout( tryAppend, 100 );
 			}
 		};
 		tryAppend();
-	}, [] );
+		return () => {
+			clearTimeout( timeoutRef.current );
+		};
+	}, [ subtitle, saveSubtitle ] );
 };
 
 registerPlugin( 'plugin-document-setting-panel-newspack-subtitle', {

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -59,8 +59,7 @@ const appendSubtitleToTitleDOMElement = ( subtitle, editorDoc, callback ) => {
 			subtitleEl.id = SUBTITLE_ID;
 			titleParent.insertBefore( subtitleEl, titleWrapperEl.nextSibling );
 		}
-		// Only update textContent if it differs, to avoid frustrating fast
-		// typists.
+		// Only update textContent if it differs, to avoid frustrating fast typists.
 		if ( subtitleEl.textContent !== subtitle ) {
 			subtitleEl.textContent = subtitle;
 		}

--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -84,6 +84,11 @@ const NewspackSubtitlePanel = () => {
 		},
 		[ editPost ]
 	);
+	// Keep current subtitle state visible within effect.
+	const subtitleRef = useRef( subtitle );
+	useEffect( () => {
+		subtitleRef.current = subtitle;
+	}, [ subtitle ] );
 	// Mount effect: poll for canvas, then create element.
 	const timeoutRef = useRef();
 	useEffect( () => {
@@ -93,7 +98,7 @@ const NewspackSubtitlePanel = () => {
 			const editorDoc = getEditorCanvas();
 			const titleWrapperEl = editorDoc.querySelector( '.edit-post-visual-editor__post-title-wrapper' );
 			if ( titleWrapperEl ) {
-				appendSubtitleToTitleDOMElement( subtitle, editorDoc, saveSubtitle );
+				appendSubtitleToTitleDOMElement( subtitleRef.current, editorDoc, saveSubtitle );
 			} else if ( retryCount < maxRetries ) {
 				retryCount++;
 				timeoutRef.current = setTimeout( tryAppend, 100 );

--- a/includes/blocks/subtitle-block/site-editor.js
+++ b/includes/blocks/subtitle-block/site-editor.js
@@ -11,7 +11,7 @@ import { useEntityProp } from '@wordpress/core-data';
 
 import metadata from './block.json';
 
-const EditComponent = ( { context: { postType, postId } } ) => {
+const EditComponent = ( { context: { postType, postId } = {} } ) => {
 	const blockProps = useBlockProps();
 	const [ postMeta = {} ] = useEntityProp( 'postType', postType, 'meta', postId );
 	const subtitle = postMeta[ newspack_block_theme_subtitle_block.post_meta_name ] || __( 'Article subtitle', 'newspack-block-theme' );
@@ -25,7 +25,6 @@ const blockData = {
 		foreground: '#36f',
 	},
 	edit: EditComponent,
-	usesContext: [ 'postId', 'postType' ],
 	...metadata,
 };
 

--- a/includes/blocks/subtitle-block/site-editor.js
+++ b/includes/blocks/subtitle-block/site-editor.js
@@ -19,7 +19,6 @@ const EditComponent = ( { context: { postType, postId } } ) => {
 };
 
 const blockData = {
-	apiVersion: 3,
 	title: __( 'Article Subtitle', 'newspack-block-theme' ),
 	icon: {
 		src: <Icon icon={ listView } />,

--- a/includes/blocks/subtitle-block/site-editor.js
+++ b/includes/blocks/subtitle-block/site-editor.js
@@ -4,6 +4,7 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { Icon, listView } from '@wordpress/icons';
 import { useEntityProp } from '@wordpress/core-data';
@@ -11,11 +12,14 @@ import { useEntityProp } from '@wordpress/core-data';
 import metadata from './block.json';
 
 const EditComponent = ( { context: { postType, postId } } ) => {
+	const blockProps = useBlockProps();
 	const [ postMeta = {} ] = useEntityProp( 'postType', postType, 'meta', postId );
-	return postMeta[ newspack_block_theme_subtitle_block.post_meta_name ] || __( 'Article subtitle', 'newspack-block-theme' );
+	const subtitle = postMeta[ newspack_block_theme_subtitle_block.post_meta_name ] || __( 'Article subtitle', 'newspack-block-theme' );
+	return <p { ...blockProps }>{ subtitle }</p>;
 };
 
 const blockData = {
+	apiVersion: 3,
 	title: __( 'Article Subtitle', 'newspack-block-theme' ),
 	icon: {
 		src: <Icon icon={ listView } />,

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -20,7 +20,7 @@ final class Core {
 	public static function init() {
 		\add_action( 'after_setup_theme', [ __CLASS__, 'theme_support' ] );
 		\add_action( 'wp_enqueue_scripts', [ __CLASS__, 'theme_styles' ] );
-		\add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'editor_scripts' ] );
+		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
 		\add_filter( 'body_class', [ __CLASS__, 'body_class' ] );
 		\add_filter( 'block_type_metadata', [ __CLASS__, 'block_variations' ] );
 	}
@@ -78,7 +78,10 @@ final class Core {
 	/**
 	 * Enqueue editor scripts.
 	 */
-	public static function editor_scripts() {
+	public static function enqueue_block_assets() {
+		if ( ! wp_should_load_block_editor_scripts_and_styles() ) {
+			return;
+		}
 		// Enqueue editor JavaScript.
 		wp_enqueue_script( 'editor-script', get_theme_file_uri( '/dist/editor.js' ), array( 'wp-blocks', 'wp-dom' ), wp_get_theme()->get( 'Version' ), true );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR updates the following block for compatibility with the iframed Post Editor:
* `newspack-block-theme/article-subtitle`

Addresses [NPPM-2588: Newspack Block Theme (iframe Editor Compatibility)](https://linear.app/a8c/issue/NPPM-2588/newspack-block-theme-iframe-editor-compatibility).

### How to test the changes in this Pull Request:

#### Prerequisites

1. Install and activate `newspack-block-theme`. 
2. Make sure no other plugins are activated!
3. Create or choose a post and add a subtitle to its metadata.  If you've got access to the CLI:
   ```
   wp post meta update <POST_ID> newspack_post_subtitle "This is a test subtitle"
   ```
   Note the post ID — you'll use the same post throughout testing.

#### Part 1: Post Editor — Verify the bug (before the PR)

Make sure `newspack-block-theme` is on the **trunk** branch (the state before this PR). 

1. Open the test post in the editor (`/wp-admin/post.php?post=<POST_ID>&action=edit`).
2. Check whether the Post Editor is in iframe mode:  in the DOM, the editor pane will be wrapped in an `<iframe>` tag if so.  (Unlike other tests, the Post Editor will probably already be in iframe mode due to how the subtitle block is injected.)
4. With iframe mode active, look below the post title in the editor canvas. The subtitle field should be **missing**.
5. Visit the post on the frontend (`/?p=<POST_ID>`). The subtitle should still render correctly.

#### Part 2: Post Editor — Verify the fix (after the PR)

1. Apply this PR and rebuild.
2. Open the same test post in the editor.
3. Confirm the Post Editor is iframed.
4. Below the post title, verify you see an editable subtitle field.
6. Click the subtitle field, change the text, and save the post.
7. Refresh the editor — the updated subtitle should persist.
8. Visit the post on the frontend — the subtitle should show the updated text.

### Other information:

#### Additional fixes

This PR addresses a few issues beyond the migration that either made testing difficult, or involved code we were changing already.  I've been urged by Claude to list them here:

1. **Unescaped subtitle in PHP render callback** — `$post_subtitle` was output as raw HTML in `sprintf()`. Now wrapped in `esc_html()`.  Fixed to avoid breaking test site when uploading odd test subtitles.  (`class-subtitle-block.php:55`)
2. **`innerHTML` used for plain text in post editor** — The contenteditable input handler, comparison, and assignment all used `innerHTML` where `textContent` is appropriate. Now uses `textContent` throughout. Belt-and-suspenders fix with the above.  (`post-editor.js:57, 64-65`)
3. **Missing `style.id` caused duplicate style tags** — The `<style>` element was never assigned `SUBTITLE_STYLE_ID`, so the `getElementById` deduplication check always returned `null`, injecting a new `<style>` tag on every call. Cosmetic, but caused confusion. (`post-editor.js:38`)
4. **Site-editor/post-editor enqueue fall-through** The site-editor `if` block didn't prevent execution from continuing to the post-editor check. Now uses `if/elseif` to make mutual exclusivity explicit. (`class-subtitle-block.php:71-79`)
5. **Redundant `apiVersion: 3` in site-editor.js** Set explicitly then immediately overwritten by `...metadata` spread from `block.json`. Tests as unneeded, and flagged by AI reviewers. (`site-editor.js:22`)



* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
