### PR TITLE
feat(yoast): filter core/post-terms to show primary category

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -25,3 +25,4 @@ require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/blocks/index.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-patterns.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-jetpack.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-woocommerce.php';
+require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-primary-category.php';

--- a/includes/class-primary-category.php
+++ b/includes/class-primary-category.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Primary Category support for the block theme.
+ *
+ * Filters the core/post-terms block output to show only the
+ * primary category when set via Yoast SEO.
+ *
+ * @package Newspack_Block_Theme
+ */
+
+namespace Newspack_Block_Theme;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Primary Category class.
+ */
+final class Primary_Category {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_filter( 'render_block', [ __CLASS__, 'filter_post_terms' ], 10, 2 );
+	}
+
+	/**
+	 * Filter the core/post-terms block to show only the primary category.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $block         The block data.
+	 * @return string Modified block content.
+	 */
+	public static function filter_post_terms( $block_content, $block ) {
+		// Only filter core/post-terms for the category taxonomy.
+		if ( 'core/post-terms' !== $block['blockName'] ) {
+			return $block_content;
+		}
+
+		$term = $block['attrs']['term'] ?? 'post_tag';
+		if ( 'category' !== $term ) {
+			return $block_content;
+		}
+
+		// Don't filter in admin or REST API contexts.
+		if ( \is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+			return $block_content;
+		}
+
+		// Ensure the Newspack Primary_Category utility is available.
+		if ( ! class_exists( '\Newspack\Primary_Category' ) ) {
+			return $block_content;
+		}
+
+		$category = \Newspack\Primary_Category::get();
+		if ( ! $category ) {
+			return $block_content;
+		}
+
+		// Build the primary category link.
+		$category_link = \get_category_link( $category->term_id );
+		$link_html     = '<a href="' . \esc_url( $category_link ) . '" rel="tag">' . \esc_html( $category->name ) . '</a>';
+
+		// Replace the inner content of the wrapper element, preserving wrapper attributes.
+		$block_content = preg_replace(
+			'/(<div[^>]*class="[^"]*wp-block-post-terms[^"]*"[^>]*>).*(<\/div>)/s',
+			'$1' . $link_html . '$2',
+			$block_content
+		);
+
+		return $block_content;
+	}
+}
+
+Primary_Category::init();

--- a/includes/class-primary-category.php
+++ b/includes/class-primary-category.php
@@ -58,16 +58,29 @@ final class Primary_Category {
 
 		// Build the primary category link.
 		$category_link = \get_category_link( $category->term_id );
-		$link_html     = '<a href="' . \esc_url( $category_link ) . '" rel="tag">' . \esc_html( $category->name ) . '</a>';
+		if ( ! $category_link || \is_wp_error( $category_link ) ) {
+			return $block_content;
+		}
+		$link_html = '<a href="' . \esc_url( $category_link ) . '" rel="tag">' . \esc_html( $category->name ) . '</a>';
 
-		// Replace the inner content of the wrapper element, preserving wrapper attributes.
-		$block_content = preg_replace(
+		// Extract prefix and suffix spans if present, then rebuild inner content.
+		$prefix = '';
+		$suffix = '';
+		if ( preg_match( '/<span[^>]*class="[^"]*wp-block-post-terms__prefix[^"]*"[^>]*>.*?<\/span>/s', $block_content, $matches ) ) {
+			$prefix = $matches[0];
+		}
+		if ( preg_match( '/<span[^>]*class="[^"]*wp-block-post-terms__suffix[^"]*"[^>]*>.*?<\/span>/s', $block_content, $matches ) ) {
+			$suffix = $matches[0];
+		}
+
+		// Replace the inner content of the wrapper element, preserving wrapper attributes, prefix, and suffix.
+		$result = preg_replace(
 			'/(<div[^>]*class="[^"]*wp-block-post-terms[^"]*"[^>]*>).*(<\/div>)/s',
-			'$1' . $link_html . '$2',
+			'$1' . $prefix . $link_html . $suffix . '$2',
 			$block_content
 		);
 
-		return $block_content;
+		return null !== $result ? $result : $block_content;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When Yoast SEO's primary category is set on a post, the `core/post-terms` block now displays only that primary category instead of all assigned categories. This applies to single posts, archives, and search results in the block theme. The feature relies on the shared `Newspack\Primary_Category` utility from newspack-plugin and gracefully degrades when the plugin is not available or Yoast is inactive.

Closes NPPD-1346.

**Depends on:** Automattic/newspack-plugin#4563 (the shared utility PR)

### How to test the changes in this Pull Request:

1. Ensure Yoast SEO and newspack-plugin (from the `feat/yoast-primary-category-support` branch) are active.
2. Create or edit a post and assign it to multiple categories.
3. In the Yoast SEO meta box, set one category as the primary category.
4. View the post on the front end and confirm only the primary category is displayed where `core/post-terms` renders (post header, archive listings).
5. Edit another post that has multiple categories but no explicit primary category set by Yoast. Confirm all categories display as usual (Yoast sets a default primary, so you may need to verify via the `_yoast_wpseo_primary_category` meta).
6. Go to Newspack > Settings > Advanced Settings and toggle "Use Yoast primary category" off. Save.
7. Return to the post from step 3 and confirm all categories now display.
8. Toggle the setting back on and confirm the primary category filtering resumes.
9. Deactivate Yoast SEO. Confirm all categories display normally with no errors.
10. Deactivate newspack-plugin. Confirm the block theme renders categories normally with no errors.
11. Check that the admin editor is unaffected (categories should always show all terms in the editor).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
