### PR TITLE
feat(post-date): add modified date block to post-meta patterns

### DIFF
--- a/patterns/post-meta/post-meta-compact.php
+++ b/patterns/post-meta/post-meta-compact.php
@@ -27,5 +27,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"fontSize":"x-small"} /-->
 
+<!-- wp:post-date {"displayType":"modified","fontSize":"x-small"} /-->
+
 </div>
 <!-- /wp:group -->

--- a/patterns/post-meta/post-meta-multiple-lines-avatar.php
+++ b/patterns/post-meta/post-meta-multiple-lines-avatar.php
@@ -41,7 +41,9 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <?php endif; ?>
 
-<!-- wp:post-date {"format":"F j, Y"} /--></div>
+<!-- wp:post-date {"format":"F j, Y"} /-->
+
+<!-- wp:post-date {"displayType":"modified","format":"F j, Y"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/patterns/post-meta/post-meta-multiple-lines.php
+++ b/patterns/post-meta/post-meta-multiple-lines.php
@@ -28,7 +28,9 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <?php endif; ?>
 
-<!-- wp:post-date {"format":"F j, Y","lock":{"move":true,"remove":true}} /--></div>
+<!-- wp:post-date {"format":"F j, Y","lock":{"move":true,"remove":true}} /-->
+
+<!-- wp:post-date {"displayType":"modified","format":"F j, Y","lock":{"move":true,"remove":false}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons"} /-->

--- a/patterns/post-meta/post-meta-multiple-lines.php
+++ b/patterns/post-meta/post-meta-multiple-lines.php
@@ -30,7 +30,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"format":"F j, Y","lock":{"move":true,"remove":true}} /-->
 
-<!-- wp:post-date {"displayType":"modified","format":"F j, Y","lock":{"move":true,"remove":false}} /--></div>
+<!-- wp:post-date {"displayType":"modified","format":"F j, Y","lock":{"move":true,"remove":true}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons"} /-->

--- a/patterns/post-meta/post-meta-single-line-avatar.php
+++ b/patterns/post-meta/post-meta-single-line-avatar.php
@@ -40,7 +40,9 @@ $registry = WP_Block_Type_Registry::get_instance();
 <hr class="wp-block-separator has-alpha-channel-opacity is-style-thick" style="margin-top:0;margin-bottom:0"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date {"lock":{"move":true,"remove":true}} /--></div>
+<!-- wp:post-date {"lock":{"move":true,"remove":true}} /-->
+
+<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":false}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons-center"} /-->

--- a/patterns/post-meta/post-meta-single-line-avatar.php
+++ b/patterns/post-meta/post-meta-single-line-avatar.php
@@ -42,7 +42,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"lock":{"move":true,"remove":true}} /-->
 
-<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":false}} /--></div>
+<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":true}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons-center"} /-->

--- a/patterns/post-meta/post-meta-single-line.php
+++ b/patterns/post-meta/post-meta-single-line.php
@@ -34,7 +34,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"lock":{"move":true,"remove":true}} /-->
 
-<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":false}} /--></div>
+<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":true}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons-center"} /-->

--- a/patterns/post-meta/post-meta-single-line.php
+++ b/patterns/post-meta/post-meta-single-line.php
@@ -32,7 +32,9 @@ $registry = WP_Block_Type_Registry::get_instance();
 <hr class="wp-block-separator has-alpha-channel-opacity is-style-thick" style="margin-top:0;margin-bottom:0"/>
 <!-- /wp:separator -->
 
-<!-- wp:post-date {"lock":{"move":true,"remove":true}} /--></div>
+<!-- wp:post-date {"lock":{"move":true,"remove":true}} /-->
+
+<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":false}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons-center"} /-->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a `core/post-date` block with `displayType: modified` to all 5 post-meta patterns, placed after the publish date block. The plugin's `render_block_core/post-date` filter handles visibility, the "Updated" label, and time-ago conversion.

Sites with customized templates will need to reset them or manually add the modified date block.

Companion PRs:
- https://github.com/Automattic/newspack-plugin/pull/4579
- https://github.com/Automattic/newspack-theme/pull/2652

Closes NPPD-1277, NPPD-1278.

### How to test the changes in this Pull Request:

See the plugin PR linked above for comprehensive testing steps covering the block theme.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?