### PR TITLE
fix(post-date): use block bindings instead of deprecated displayType

### DIFF
--- a/patterns/post-meta/post-meta-compact.php
+++ b/patterns/post-meta/post-meta-compact.php
@@ -27,7 +27,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"fontSize":"x-small"} /-->
 
-<!-- wp:post-date {"displayType":"modified","fontSize":"x-small"} /-->
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"modified"}}}},"className":"wp-block-post-date__modified-date","fontSize":"x-small"} /-->
 
 </div>
 <!-- /wp:group -->

--- a/patterns/post-meta/post-meta-multiple-lines-avatar.php
+++ b/patterns/post-meta/post-meta-multiple-lines-avatar.php
@@ -43,7 +43,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"format":"F j, Y"} /-->
 
-<!-- wp:post-date {"displayType":"modified","format":"F j, Y"} /--></div>
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"modified"}}}},"className":"wp-block-post-date__modified-date","format":"F j, Y"} /--></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 

--- a/patterns/post-meta/post-meta-multiple-lines.php
+++ b/patterns/post-meta/post-meta-multiple-lines.php
@@ -30,7 +30,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"format":"F j, Y","lock":{"move":true,"remove":true}} /-->
 
-<!-- wp:post-date {"displayType":"modified","format":"F j, Y","lock":{"move":true,"remove":true}} /--></div>
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"modified"}}}},"className":"wp-block-post-date__modified-date","format":"F j, Y","lock":{"move":true,"remove":true}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons"} /-->

--- a/patterns/post-meta/post-meta-single-line-avatar.php
+++ b/patterns/post-meta/post-meta-single-line-avatar.php
@@ -42,7 +42,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"lock":{"move":true,"remove":true}} /-->
 
-<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":true}} /--></div>
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"modified"}}}},"className":"wp-block-post-date__modified-date","lock":{"move":true,"remove":true}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons-center"} /-->

--- a/patterns/post-meta/post-meta-single-line.php
+++ b/patterns/post-meta/post-meta-single-line.php
@@ -34,7 +34,7 @@ $registry = WP_Block_Type_Registry::get_instance();
 
 <!-- wp:post-date {"lock":{"move":true,"remove":true}} /-->
 
-<!-- wp:post-date {"displayType":"modified","lock":{"move":true,"remove":true}} /--></div>
+<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"modified"}}}},"className":"wp-block-post-date__modified-date","lock":{"move":true,"remove":true}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:pattern {"slug":"newspack-block-theme/jetpack-sharing-buttons-center"} /-->


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to #428. Updates all 5 post-meta patterns to use the modern WordPress Block Bindings API for the modified date block instead of the deprecated `displayType` attribute.

Before: `<!-- wp:post-date {"displayType":"modified"} /-->`
After: `<!-- wp:post-date {"metadata":{"bindings":{"datetime":{"source":"core/post-data","args":{"field":"modified"}}}},"className":"wp-block-post-date__modified-date"} /-->`

The `displayType` attribute was superseded by Block Bindings in [WordPress/gutenberg#70585](https://github.com/WordPress/gutenberg/pull/70585). WordPress still renders it via a legacy fallback, but the attribute is no longer in the block schema and the editor UI doesn't recognize it as the "Modified Date" variation.

The `wp-block-post-date__modified-date` CSS class is included for styling and detection purposes.

Closes NPPD-1278.

### How to test the changes in this Pull Request:

1. Activate the Newspack Block Theme and enable "Show last updated date" in the plugin settings.
2. Reset the Single Posts template (Site Editor > Templates > Single Posts > Actions > Reset).
3. View a post modified well after publication. Verify both dates render correctly.
4. Open the Single Posts template in the Site Editor. Verify the modified date block shows as "Modified Date" in the block toolbar (not just "Post Date").
5. Verify the rendered HTML includes the `wp-block-post-date__modified-date` class on the modified date block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?