### PR TITLE
fix: improve pagination, linking directly to comments

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -63,8 +63,9 @@ final class Core {
 
 		// Strings for translation.
 		$newspack_l10n = array(
-			'close_menu'   => esc_html__( 'Close Menu', 'newspack-block-theme' ),
-			'close_search' => esc_html__( 'Close Search', 'newspack-block-theme' ),
+			'close_menu'       => esc_html__( 'Close Menu', 'newspack-block-theme' ),
+			'close_search'     => esc_html__( 'Close Search', 'newspack-block-theme' ),
+			'comment_too_fast' => esc_html__( 'You are posting comments too quickly. Please wait a moment before trying again.', 'newspack-block-theme' ),
 		);
 		if ( wp_script_is( 'jetpack-instant-search', 'enqueued' ) ) {
 			$newspack_l10n['jetpack_instant_search'] = 'true';

--- a/parts/comments-contents.html
+++ b/parts/comments-contents.html
@@ -17,7 +17,7 @@
 
 <!-- wp:comment-author-name /-->
 
-<!-- wp:comment-date {"format":"M j, Y g:i A","isLink":false} /-->
+<!-- wp:comment-date {"format":"M j, Y g:i A"} /-->
 
 <!-- wp:comment-edit-link /--></div>
 <!-- /wp:group -->

--- a/src/js/front-end/menus/comments.js
+++ b/src/js/front-end/menus/comments.js
@@ -70,12 +70,13 @@ const loadCommentPage = ( url, contents ) => {
 			if ( ! response.ok ) {
 				throw new Error( response.statusText );
 			}
-			return response.text();
+			const finalUrl = response.url;
+			return response.text().then( html => ( { html, finalUrl } ) );
 		} )
-		.then( html => {
+		.then( ( { html, finalUrl } ) => {
 			const doc = new DOMParser().parseFromString( html, 'text/html' );
-			if ( ! swapCommentsBlock( doc, url, contents ) ) {
-				window.location.href = url;
+			if ( ! swapCommentsBlock( doc, finalUrl, contents ) ) {
+				window.location.href = finalUrl;
 			}
 		} )
 		.catch( () => {

--- a/src/js/front-end/menus/comments.js
+++ b/src/js/front-end/menus/comments.js
@@ -26,8 +26,8 @@ const swapCommentsBlock = ( doc, finalUrl, contents ) => {
 
 	commentsBlock.replaceWith( newBlock );
 
-	// Update the URL so refresh / auto-open logic stays accurate.
-	history.pushState( null, doc.title, finalUrl );
+	// Update the URL so refresh / auto-open logic stays accurate without adding a new history entry.
+	history.replaceState( null, doc.title, finalUrl );
 
 	// Scroll to the new comment if the URL has a hash, otherwise scroll to top.
 	const hash = new URL( finalUrl ).hash;

--- a/src/js/front-end/menus/comments.js
+++ b/src/js/front-end/menus/comments.js
@@ -5,6 +5,50 @@ import { domReady } from '../utils';
 import { createMenu, createFocusTrap } from './index';
 
 /**
+ * Swaps the .wp-block-comments element inside the panel with the one found in
+ * the parsed HTML document, then updates the URL and focus trap.
+ *
+ * @param {Document}    doc      Parsed HTML document from a fetch response.
+ * @param {string}      finalUrl The URL of the fetched page (after any redirects).
+ * @param {HTMLElement} contents The .comments-menu__contents panel element.
+ */
+const swapCommentsBlock = ( doc, finalUrl, contents ) => {
+	const commentsBlock = contents.querySelector( '.wp-block-comments' );
+	if ( ! commentsBlock ) {
+		return false;
+	}
+
+	const newBlock = doc.querySelector( '.comments-menu__contents .wp-block-comments' ) || doc.querySelector( '.wp-block-comments' );
+
+	if ( ! newBlock ) {
+		return false;
+	}
+
+	commentsBlock.replaceWith( newBlock );
+
+	// Update the URL so refresh / auto-open logic stays accurate.
+	history.pushState( null, doc.title, finalUrl );
+
+	// Scroll to the new comment if the URL has a hash, otherwise scroll to top.
+	const hash = new URL( finalUrl ).hash;
+	if ( hash ) {
+		setTimeout( () => {
+			const target = contents.querySelector( hash );
+			if ( target ) {
+				target.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+			}
+		}, 100 );
+	} else {
+		contents.scrollTop = 0;
+	}
+
+	// Re-create the focus trap now that the DOM has changed.
+	createFocusTrap( contents );
+
+	return true;
+};
+
+/**
  * Loads a comment page via fetch and swaps the comments block content in the
  * panel without a full page reload.
  *
@@ -30,30 +74,54 @@ const loadCommentPage = ( url, contents ) => {
 		} )
 		.then( html => {
 			const doc = new DOMParser().parseFromString( html, 'text/html' );
-
-			// Pull the updated comments block from the fetched page.
-			// Use the panel-specific selector so we don't grab a full-page comments section.
-			const newBlock = doc.querySelector( '.comments-menu__contents .wp-block-comments' ) || doc.querySelector( '.wp-block-comments' );
-
-			if ( ! newBlock ) {
+			if ( ! swapCommentsBlock( doc, url, contents ) ) {
 				window.location.href = url;
-				return;
 			}
-
-			commentsBlock.replaceWith( newBlock );
-
-			// Update the URL so refresh / auto-open logic stays accurate.
-			history.pushState( null, doc.title, url );
-
-			// Scroll the panel back to the top of the new content.
-			contents.scrollTop = 0;
-
-			// Re-create the focus trap now that the DOM has changed.
-			createFocusTrap( contents );
 		} )
 		.catch( () => {
 			// On any error, fall back to normal navigation so pagination still works.
 			window.location.href = url;
+		} );
+};
+
+/**
+ * Submits the comment form via fetch and swaps the comments block content in
+ * the panel without a full page reload, keeping the panel open.
+ *
+ * @param {HTMLFormElement} form     The comment form element.
+ * @param {HTMLElement}     contents The .comments-menu__contents panel element.
+ */
+const submitCommentForm = ( form, contents ) => {
+	const commentsBlock = contents.querySelector( '.wp-block-comments' );
+	if ( ! commentsBlock ) {
+		return;
+	}
+
+	// Show a loading state by reducing opacity.
+	commentsBlock.style.opacity = '0.4';
+	commentsBlock.style.pointerEvents = 'none';
+
+	fetch( form.action, {
+		method: 'POST',
+		body: new FormData( form ),
+		redirect: 'follow',
+	} )
+		.then( response => {
+			if ( ! response.ok ) {
+				throw new Error( response.statusText );
+			}
+			const finalUrl = response.url;
+			return response.text().then( html => ( { html, finalUrl } ) );
+		} )
+		.then( ( { html, finalUrl } ) => {
+			const doc = new DOMParser().parseFromString( html, 'text/html' );
+			if ( ! swapCommentsBlock( doc, finalUrl, contents ) ) {
+				form.submit();
+			}
+		} )
+		.catch( () => {
+			// On any error, fall back to normal form submission.
+			form.submit();
 		} );
 };
 
@@ -87,6 +155,20 @@ domReady( function () {
 			}
 			event.preventDefault();
 			loadCommentPage( link.href, contents );
+		} );
+
+		// Intercept comment form submission to keep the panel open after posting.
+		contents.addEventListener( 'submit', event => {
+			const form = event.target.closest( '#commentform' );
+			if ( ! form ) {
+				return;
+			}
+			// Only intercept same-origin form actions.
+			if ( new URL( form.action ).origin !== window.location.origin ) {
+				return;
+			}
+			event.preventDefault();
+			submitCommentForm( form, contents );
 		} );
 	}
 

--- a/src/js/front-end/menus/comments.js
+++ b/src/js/front-end/menus/comments.js
@@ -4,18 +4,111 @@
 import { domReady } from '../utils';
 import { createMenu, createFocusTrap } from './index';
 
+/**
+ * Loads a comment page via fetch and swaps the comments block content in the
+ * panel without a full page reload.
+ *
+ * @param {string}      url      The URL to fetch (comment pagination link).
+ * @param {HTMLElement} contents The .comments-menu__contents panel element.
+ */
+const loadCommentPage = ( url, contents ) => {
+	const commentsBlock = contents.querySelector( '.wp-block-comments' );
+	if ( ! commentsBlock ) {
+		return;
+	}
+
+	// Show a loading state by reducing opacity.
+	commentsBlock.style.opacity = '0.4';
+	commentsBlock.style.pointerEvents = 'none';
+
+	fetch( url )
+		.then( response => {
+			if ( ! response.ok ) {
+				throw new Error( response.statusText );
+			}
+			return response.text();
+		} )
+		.then( html => {
+			const doc = new DOMParser().parseFromString( html, 'text/html' );
+
+			// Pull the updated comments block from the fetched page.
+			// Use the panel-specific selector so we don't grab a full-page comments section.
+			const newBlock = doc.querySelector( '.comments-menu__contents .wp-block-comments' ) || doc.querySelector( '.wp-block-comments' );
+
+			if ( ! newBlock ) {
+				window.location.href = url;
+				return;
+			}
+
+			commentsBlock.replaceWith( newBlock );
+
+			// Update the URL so refresh / auto-open logic stays accurate.
+			history.pushState( null, doc.title, url );
+
+			// Scroll the panel back to the top of the new content.
+			contents.scrollTop = 0;
+
+			// Re-create the focus trap now that the DOM has changed.
+			createFocusTrap( contents );
+		} )
+		.catch( () => {
+			// On any error, fall back to normal navigation so pagination still works.
+			window.location.href = url;
+		} );
+};
+
 domReady( function () {
+	const contents = document.querySelector( '.comments-menu__contents' );
+
 	createMenu( {
 		menuType: 'comments-menu',
 		containerSelector: '.comments-menu',
 		toggleSelector: '.comments-menu__toggle',
 		contentsSelector: '.comments-menu__contents',
-		onOpen: contents => {
+		onOpen: panelContents => {
 			// Wait a bit for any dynamic content to load (like Disqus)
 			setTimeout( () => {
 				// Re-create focus trap after dynamic content loads
-				createFocusTrap( contents );
+				createFocusTrap( panelContents );
 			}, 100 );
 		},
 	} ).init();
+
+	// Intercept pagination clicks inside the comment panel and load the new page inline rather than reloading page.
+	if ( contents ) {
+		contents.addEventListener( 'click', event => {
+			const link = event.target.closest( '.wp-block-comments-pagination a' );
+			if ( ! link ) {
+				return;
+			}
+			// Only intercept same-origin links.
+			if ( new URL( link.href ).origin !== window.location.origin ) {
+				return;
+			}
+			event.preventDefault();
+			loadCommentPage( link.href, contents );
+		} );
+	}
+
+	// Auto-open the comments panel when the page loads via a comment pagination link (?cpage=N or /comment-page-N/) or a direct comment link (#comment-N).
+	const isCommentPagination = /[?&]cpage=\d+/.test( window.location.search ) || /\/comment-page-\d+\//i.test( window.location.pathname );
+	const commentHash = /^#comment-\d+$/.test( window.location.hash ) ? window.location.hash : null;
+
+	if ( isCommentPagination || commentHash ) {
+		// The first .comments-menu__toggle in the DOM is the outer "Comments" open button.
+		const toggle = document.querySelector( '.comments-menu__toggle' );
+		if ( toggle ) {
+			toggle.click();
+
+			// After the panel's slide-in animation (250ms), scroll to the target comment.
+			if ( commentHash ) {
+				setTimeout( () => {
+					const target = document.querySelector( commentHash );
+					if ( target ) {
+						target.scrollIntoView( { behavior: 'smooth', block: 'start' } );
+					}
+				}, 400 );
+			}
+		}
+	}
 } );

--- a/src/js/front-end/menus/comments.js
+++ b/src/js/front-end/menus/comments.js
@@ -3,6 +3,7 @@
  */
 import { domReady } from '../utils';
 import { createMenu, createFocusTrap } from './index';
+import { ANIMATION_DURATION } from './consts';
 
 /**
  * Swaps the .wp-block-comments element inside the panel with the one found in
@@ -183,14 +184,14 @@ domReady( function () {
 		if ( toggle ) {
 			toggle.click();
 
-			// After the panel's slide-in animation (250ms), scroll to the target comment.
+			// After the panel's slide-in animation, scroll to the target comment.
 			if ( commentHash ) {
 				setTimeout( () => {
 					const target = document.querySelector( commentHash );
 					if ( target ) {
 						target.scrollIntoView( { behavior: 'smooth', block: 'start' } );
 					}
-				}, 400 );
+				}, ANIMATION_DURATION.POSITION + 150 );
 			}
 		}
 	}

--- a/src/js/front-end/menus/comments.js
+++ b/src/js/front-end/menus/comments.js
@@ -212,7 +212,8 @@ domReady( function () {
 	}
 
 	// Auto-open the comments panel when the page loads via a comment pagination link (?cpage=N or /comment-page-N/) or a direct comment link (#comment-N).
-	const isCommentPagination = /[?&]cpage=\d+/.test( window.location.search ) || /\/comment-page-\d+\//i.test( window.location.pathname );
+	const isCommentPagination =
+		new URLSearchParams( window.location.search ).has( 'cpage' ) || /\/comment-page-\d+\//i.test( window.location.pathname );
 	const commentHash = /^#comment-\d+$/.test( window.location.hash ) ? window.location.hash : null;
 
 	if ( isCommentPagination || commentHash ) {

--- a/src/js/front-end/menus/comments.js
+++ b/src/js/front-end/menus/comments.js
@@ -87,6 +87,25 @@ const loadCommentPage = ( url, contents ) => {
 };
 
 /**
+ * Shows an error message inside the comment form and re-enables it.
+ *
+ * @param {HTMLFormElement} form    The comment form element.
+ * @param {string}          message The error message to display.
+ */
+const showCommentFormError = ( form, message ) => {
+	let noticeEl = form.querySelector( '.newspack-ui__notice--error' );
+	if ( ! noticeEl ) {
+		const wrapper = document.createElement( 'div' );
+		wrapper.className = 'newspack-ui';
+		noticeEl = document.createElement( 'p' );
+		noticeEl.className = 'newspack-ui__notice newspack-ui__notice--error';
+		wrapper.appendChild( noticeEl );
+		form.prepend( wrapper );
+	}
+	noticeEl.textContent = message;
+};
+
+/**
  * Submits the comment form via fetch and swaps the comments block content in
  * the panel without a full page reload, keeping the panel open.
  *
@@ -109,21 +128,39 @@ const submitCommentForm = ( form, contents ) => {
 		redirect: 'follow',
 	} )
 		.then( response => {
+			// Handle rate limiting with a user-visible message rather than a
+			// silent fallback — the native form.submit() would hit the same limit.
+			if ( response.status === 429 ) {
+				commentsBlock.style.opacity = '';
+				commentsBlock.style.pointerEvents = '';
+				showCommentFormError(
+					form,
+					window.newspackScreenReaderText?.comment_too_fast ||
+						'You are posting comments too quickly. Please wait a moment before trying again.'
+				);
+				return null;
+			}
 			if ( ! response.ok ) {
 				throw new Error( response.statusText );
 			}
 			const finalUrl = response.url;
 			return response.text().then( html => ( { html, finalUrl } ) );
 		} )
-		.then( ( { html, finalUrl } ) => {
+		.then( result => {
+			if ( ! result ) {
+				return;
+			}
+			const { html, finalUrl } = result;
 			const doc = new DOMParser().parseFromString( html, 'text/html' );
 			if ( ! swapCommentsBlock( doc, finalUrl, contents ) ) {
-				form.submit();
+				// Use the prototype method directly — WordPress's comment form has
+				// <input name="submit"> which shadows the native form.submit().
+				HTMLFormElement.prototype.submit.call( form );
 			}
 		} )
 		.catch( () => {
 			// On any error, fall back to normal form submission.
-			form.submit();
+			HTMLFormElement.prototype.submit.call( form );
 		} );
 };
 

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -223,3 +223,8 @@ footer {
 		}
 	}
 }
+
+// Fallback for .newspack-ui__notice--error when newspack-ui styles are not loaded.
+.newspack-ui__notice--error {
+	color: var(--newspack-ui-color-error-50, #d63638);
+}

--- a/src/scss/overlays/_base.scss
+++ b/src/scss/overlays/_base.scss
@@ -5,7 +5,7 @@
 	overflow-y: hidden;
 
 	@include sass-utils.media(medium) {
-		&:not(.menu-open--search-menu) {
+		&:not(.menu-open--search-menu,.menu-open--comments-menu) {
 			overflow-y: auto;
 		}
 	}

--- a/src/scss/overlays/_comments.scss
+++ b/src/scss/overlays/_comments.scss
@@ -17,6 +17,10 @@
 				calc((var(--wp--style--global--content-size) - (var(--wp--preset--spacing--50) * 5)) / 6 * 7 +
 				(var(--wp--preset--spacing--50) * 6));
 		}
+
+		.newspack-ui__notice {
+			margin-bottom: 0;
+		}
 	}
 
 	&__toggle {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR tweaks the current comment panel approach in the theme to fix a couple UX issues:
* It makes sure comments can be linked to, even when they're not on the first page
* It makes the pagination work. It should work within the panel and fetch new comments but worst case, if there's an issue it'll fallback to reloading the page, and reopening the comments to the right page.
* It also adds links to the comment date so a specific comment is easier to link directly to. 

Closes NPPD-1280.

### How to test the changes in this Pull Request:

1. Apply this PR & run `npm run build`. 
2. Set up your test site to have several comments on a post (20+) - more is better!
3. Under WP Admin > Settings > Discussion, enable comment pagination and set the comments per page to something reasonably low -- you basically want 3-4+ pages of comments.

<img width="516" height="108" alt="CleanShot 2026-03-26 at 11 34 24" src="https://github.com/user-attachments/assets/a0b4a743-1825-47f3-9f09-6771b8da67f4" />

4. Navigate to your post on the front end, scroll to the bottom, and click the Comments button.
5. In the panel that opens, try paging through the comments using the pagination at the bottom. Confirm the comments load without reloading the whole page.
6. Pick a random page, and right click on one of the comment's dates (preferably near the bottom). Copy the link, and open a new browser tab and paste it. Confirm the panel opens and it goes to that comment.  
7. While logged in, try commenting. Ensure that the comment posts, and the panel remains open.
8. While logged in, try replying to a comment, and ensure the comment posts and the panel remains open.
9. In an incognito window, repeat step 7 and 8. It should ask you for your name and email address, but allow you to comment. 
10. Under WP Admin > Settings > Discussion, check "Users must be registered and logged in to comment"; save.

<img width="609" height="115" alt="CleanShot 2026-03-26 at 12 02 45" src="https://github.com/user-attachments/assets/85e2c03d-ec17-480a-bc32-1206b8a9a35f" />

11. Back in a fresh incognito window, try to repeat step 7 or 8; confirm you see a message saying you have to log in to comment, and that the link brings you to the /wp-login.php screen. (We may want to hijack the My Account login at a future point but for now WordPress's default behaviour does the trick!). 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
