### PR TITLE
feat: switch header/footer to use WordPress's block visibility

### DIFF
--- a/.github/UTILITY_CLASSES.md
+++ b/.github/UTILITY_CLASSES.md
@@ -11,15 +11,6 @@ Note: The font size still needs to be changed to x-small if we're recreating a N
 | has-small-size   | The buttons will have a top and bottom padding of 8px and a left and right padding of 16px.                          |
 | has-x-small-size | The buttons will have a top and bottom padding of 6px, a left and right padding of 12px, and a border-radius of 4px. |
 
-# Responsive Elements
-
-`mobile-only` and `desktop-only` can be applied to blocks to display them based on the screen size.
-
-| CLASS NAME   | DESCRIPTION                                                                     |
-| ------------ | ------------------------------------------------------------------------------- |
-| mobile-only  | The block will be displayed on the screen if it is 781px wide or less.          |
-| desktop-only | The block will be displayed on the screen if the screen is at least 782px wide. |
-
 # Position
 
 ## Fixed

--- a/.github/UTILITY_CLASSES.md
+++ b/.github/UTILITY_CLASSES.md
@@ -11,10 +11,6 @@ Note: The font size still needs to be changed to x-small if we're recreating a N
 | has-small-size   | The buttons will have a top and bottom padding of 8px and a left and right padding of 16px.                          |
 | has-x-small-size | The buttons will have a top and bottom padding of 6px, a left and right padding of 12px, and a border-radius of 4px. |
 
-# Responsive Elements
-
-The Newspack Block Theme uses WordPress's blockVisibility to show/hide certain elements on desktop and mobile, including different versions of the header and footer template parts.
-
 # Position
 
 ## Fixed

--- a/.github/UTILITY_CLASSES.md
+++ b/.github/UTILITY_CLASSES.md
@@ -11,6 +11,10 @@ Note: The font size still needs to be changed to x-small if we're recreating a N
 | has-small-size   | The buttons will have a top and bottom padding of 8px and a left and right padding of 16px.                          |
 | has-x-small-size | The buttons will have a top and bottom padding of 6px, a left and right padding of 12px, and a border-radius of 4px. |
 
+# Responsive Elements
+
+The Newspack Block Theme uses WordPress's blockVisibility to show/hide certain elements on desktop and mobile, including different versions of the header and footer template parts.
+
 # Position
 
 ## Fixed

--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,3 +1,3 @@
-<!-- wp:template-part {"slug":"footer-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"footer-desktop desktop-only"} /-->
+<!-- wp:template-part {"slug":"footer-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"footer-desktop","metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}}} /-->
 
-<!-- wp:template-part {"slug":"footer-mobile","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"footer-mobile mobile-only"} /-->
+<!-- wp:template-part {"slug":"footer-mobile","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"footer-mobile", "metadata":{"blockVisibility":{"viewport":{"desktop":false}}}} /-->

--- a/parts/header.html
+++ b/parts/header.html
@@ -1,3 +1,3 @@
-<!-- wp:template-part {"slug":"header-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"header-desktop desktop-only"} /-->
+<!-- wp:template-part {"slug":"header-desktop","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"metadata":{"blockVisibility":{"viewport":{"tablet":false,"mobile":false}}},"className":"header-desktop"} /-->
 
-<!-- wp:template-part {"slug":"header-mobile","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"className":"header-mobile mobile-only"} /-->
+<!-- wp:template-part {"slug":"header-mobile","theme":"newspack-block-theme","tagName":"div","lock":{"move":true,"remove":true},"metadata":{"blockVisibility":{"viewport":{"desktop":false}}},"className":"header-mobile"} /-->

--- a/src/scss/_base.scss
+++ b/src/scss/_base.scss
@@ -118,20 +118,6 @@ ol {
 	}
 }
 
-// Mobile-only
-.mobile-only {
-	@include sass-utils.media(medium) {
-		display: none !important;
-	}
-}
-
-// Desktop-only
-.desktop-only {
-	@include sass-utils.media(small-only) {
-		display: none !important;
-	}
-}
-
 // Icons
 [class*="newspack-icon"] {
 	line-height: 0;

--- a/src/scss/_theme-description.scss
+++ b/src/scss/_theme-description.scss
@@ -4,8 +4,8 @@ Theme URI: https://github.com/automattic/newspack-block-theme
 Author: Automattic
 Author URI: https://newspack.com
 Description: A forward-looking news theme designed and developed to be highly customizable with the WordPress block editor. Brought to you by Newspack: https://newspack.com
-Requires at least: 6.2
-Tested up to: 6.8
+Requires at least: 7.0
+Tested up to: 7.0
 Requires PHP: 8.0
 Version: 1.26.0
 License: GNU General Public License v2 or later


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces the `.desktop-only` and `.mobile-only` CSS classes in the theme with WordPress's block visibility features coming in 7.0.

I optimistically removed references to the classes. Hopefully the baked-in tools will be enough for this kind of thing going forward.

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WordPress 7.0 RC; this won't work on older versions of WP.
2. Make sure the Newspack Plugin and Newsletters are up-to-date (we originally removed block visibility for WP 6.9, but re-added it; the trunk version of each plugin should include the version that re-adds it for the Newspack Plugin, and the version that still hides it for the Newspack Newsletters, but makes sure that doesn't bleed into other post types).
3. Make sure you're using the default versions of the Header and Footer template parts.
4. Apply this PR.
5. Confirm that the right header/footer is shown on desktop and mobile (that it switches from the desktop version to the mobile version as you scale the screen down).
6. Try editing the template parts and switching between the different layouts in the right column; publish. Confirm that the visibility setting is still "stuck" to the template part, and that they continue to work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
