### PR TITLE
fix(subtitle): use CSS variable for content width in post editor

### DIFF
--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -39,7 +39,7 @@ const appendSubtitleToTitleDOMElement = ( subtitle, editorDoc, callback ) => {
 			style.innerHTML = `
                 #${ SUBTITLE_ID } {
                     font-style: italic;
-                    max-width: calc(632px + var(--wp--preset--spacing--30)* 2);
+                    max-width: calc(var(--wp--style--global--content-size, 632px) + var(--wp--preset--spacing--30)* 2);
                     margin-left: auto;
                     margin-right: auto;
                     margin-bottom: 2em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The subtitle block in the post editor used a hardcoded `632px` max-width, which didn't respect custom content width values set in Global Styles. When a site operator changed the content width (e.g. to 800px), the title would expand to match but the subtitle would stay at 632px, creating a visual misalignment.

This replaces the hardcoded value with the `--wp--style--global--content-size` CSS variable (with `632px` as fallback), so the subtitle now picks up whatever content width is configured in the theme.

Closes NPPD-1273.

### How to test the changes in this Pull Request:

1. Activate the Newspack Block Theme
2. Go to Appearance > Editor > Styles > Layout and change the Content Width from 632px to a different value (e.g., 800px). Save.
3. Create or edit a post. Type a title, then click below the title to add a subtitle (the italic text area that appears between the title and the content blocks).
4. Verify the subtitle text aligns with the title edges (both should respect the same content width).
5. Change the content width back to the default 632px and verify the subtitle still aligns with the title.
6. Check the frontend preview to confirm the subtitle renders correctly there as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?