### PR TITLE
feat: copy newsletters compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Thumbs.db
 # Compiled CSS
 *.css
 style.css
+!assets/css/newspack-newsletters-editor.css
 
 # Compiled Javascript
 /dist/

--- a/assets/css/newspack-newsletters-editor.css
+++ b/assets/css/newspack-newsletters-editor.css
@@ -1,0 +1,8 @@
+/* Newspack Newsletters Block styles */
+.wp-block-image img {
+	display: block;
+}
+
+.wp-block-image figcaption {
+	text-align: left;
+}

--- a/functions.php
+++ b/functions.php
@@ -25,3 +25,4 @@ require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/blocks/index.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-patterns.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-jetpack.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-woocommerce.php';
+require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-newspack-newsletters.php';

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Newspack Newsletters Compatibility File
+ *
+ * @package Newspack_Block_Theme
+ */
+
+namespace Newspack_Block_Theme;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Newsletters compatibility.
+ */
+final class Newspack_Newsletters {
+	/**
+	 * Initializer.
+	 */
+	public static function init() {
+		if ( ! class_exists( '\Newspack_Newsletters' ) ) {
+			return;
+		}
+		\add_action( 'newspack_newsletters_enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_styles' ] );
+		\add_filter( 'newspack_newsletters_mjml_component_attributes', [ __CLASS__, 'mjml_component_attributes' ] );
+	}
+
+	/**
+	 * Enqueue Block Editor styles for the Newsletters editor.
+	 */
+	public static function enqueue_editor_styles() {
+		\add_editor_style( 'assets/css/newspack-newsletters-editor.css' );
+	}
+
+	/**
+	 * Custom MJML components attributes.
+	 *
+	 * @param array $attributes MJML component attributes.
+	 *
+	 * @return array MJML component attributes.
+	 */
+	public static function mjml_component_attributes( $attributes ) {
+		if ( isset( $attributes['css-class'] ) && 'image-caption' === $attributes['css-class'] ) {
+			$attributes['align']   = 'left';
+			$attributes['padding'] = '0';
+		}
+		return $attributes;
+	}
+}
+
+Newspack_Newsletters::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Copies the Newspack Newsletters compatibility file from the classic theme (`newspack-theme`) to the block theme. This ensures image captions in newsletters are left-aligned instead of centered.

The compatibility layer does two things:
- Enqueues editor styles that left-align image captions and set images to `display: block` in the newsletter editor.
- Filters MJML component attributes to set `align: left` and `padding: 0` on image-caption components in rendered newsletter emails.

Closes https://linear.app/a8c/issue/NPPD-1344

### How to test the changes in this Pull Request:

1. Activate the block theme and Newspack Newsletters plugin.
2. Create or edit a newsletter.
3. Add an image block with a caption.
4. Verify the caption is left-aligned in the editor (not centered).
5. Send a test email and verify the caption is left-aligned in the rendered email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?