### PR TITLE
feat: add newsletters templates

### DIFF
--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -23,6 +23,7 @@ final class Core {
 		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
 		\add_filter( 'body_class', [ __CLASS__, 'body_class' ] );
 		\add_filter( 'block_type_metadata', [ __CLASS__, 'block_variations' ] );
+		\add_filter( 'get_block_templates', [ __CLASS__, 'set_custom_template_titles' ], 10, 3 );
 	}
 
 	/**
@@ -102,6 +103,34 @@ final class Core {
 		);
 
 		return $classes;
+	}
+
+	/**
+	 * Set human-readable titles for custom post type templates.
+	 *
+	 * @param \WP_Block_Template[] $templates Array of block templates.
+	 * @param array                $query     Template query arguments.
+	 * @param string               $template_type Template type (wp_template or wp_template_part).
+	 *
+	 * @return \WP_Block_Template[] Modified array of block templates.
+	 */
+	public static function set_custom_template_titles( $templates, $query, $template_type ) {
+		if ( 'wp_template' !== $template_type ) {
+			return $templates;
+		}
+
+		$titles = [
+			'single-newspack_nl_cpt'  => \__( 'Single Newsletter', 'newspack-block-theme' ),
+			'archive-newspack_nl_cpt' => \__( 'Newsletter Archive', 'newspack-block-theme' ),
+		];
+
+		foreach ( $templates as $template ) {
+			if ( isset( $titles[ $template->slug ] ) ) {
+				$template->title = $titles[ $template->slug ];
+			}
+		}
+
+		return $templates;
 	}
 
 	/**

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -125,11 +125,9 @@ final class Core {
 		];
 
 		foreach ( $templates as $template ) {
-			if ( 'theme' !== $template->source || ! isset( $titles[ $template->slug ] ) ) {
-				continue;
+			if ( isset( $titles[ $template->slug ] ) ) {
+				$template->title = $titles[ $template->slug ];
 			}
-
-			$template->title = $titles[ $template->slug ];
 		}
 
 		return $templates;

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -125,7 +125,7 @@ final class Core {
 		];
 
 		foreach ( $templates as $template ) {
-			if ( isset( $titles[ $template->slug ] ) ) {
+			if ( isset( $titles[ $template->slug ] ) && 'theme' === $template->source ) {
 				$template->title = $titles[ $template->slug ];
 			}
 		}

--- a/includes/class-core.php
+++ b/includes/class-core.php
@@ -125,9 +125,11 @@ final class Core {
 		];
 
 		foreach ( $templates as $template ) {
-			if ( isset( $titles[ $template->slug ] ) ) {
-				$template->title = $titles[ $template->slug ];
+			if ( 'theme' !== $template->source || ! isset( $titles[ $template->slug ] ) ) {
+				continue;
 			}
+
+			$template->title = $titles[ $template->slug ];
 		}
 
 		return $templates;

--- a/templates/archive-newspack_nl_cpt.html
+++ b/templates/archive-newspack_nl_cpt.html
@@ -6,68 +6,19 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
 	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--80)">
 		<!-- wp:query-title {"type":"archive","showPrefix":false} /-->
-
-		<!-- wp:term-description /-->
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:columns {"align":"wide","className":"is-style-first-col-to-second"} -->
-	<div class="wp-block-columns alignwide is-style-first-col-to-second">
-		<!-- wp:column {"width":"50%","metadata":{"name":"Post"}} -->
-		<div class="wp-block-column" style="flex-basis:50%">
-			<!-- wp:post-template {"layout":{"type":"default"}} -->
-				<!-- wp:columns {"className":"is-style-first-col-to-second","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
-				<div class="wp-block-columns is-style-first-col-to-second" style="margin-top:0;margin-bottom:0">
-					<!-- wp:column {"width":"33.33%","metadata":{"name":"Image"}} -->
-					<div class="wp-block-column" style="flex-basis:33.33%">
-						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
-						<div class="wp-block-group">
-							<!-- wp:post-featured-image {"aspectRatio":"3/2","style":{"spacing":{"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
-							<!-- wp:newspack/featured-image-caption /-->
-						</div>
-						<!-- /wp:group -->
-					</div>
-					<!-- /wp:column -->
+	<!-- wp:post-template {"layout":{"type":"default"}} -->
+		<!-- wp:post-title {"isLink":true} /-->
 
-					<!-- wp:column {"width":"66.66%","metadata":{"name":"Content"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
-					<div class="wp-block-column" style="flex-basis:66.66%">
-						<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-						<div class="wp-block-group">
-							<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
-
-							<!-- wp:post-title {"level":4,"isLink":true} /-->
-						</div>
-						<!-- /wp:group -->
-
-						<!-- wp:newspack-block-theme/article-subtitle {} /-->
-
-						<!-- wp:post-excerpt {"showMoreOnNewLine":false,"fontSize":"small"} /-->
-
-						<!-- wp:pattern {"slug":"newspack-block-theme/post-meta-compact"} /-->
-					</div>
-					<!-- /wp:column -->
-				</div>
-				<!-- /wp:columns -->
-			<!-- /wp:post-template -->
-		</div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"width":"25%"} -->
-		<div class="wp-block-column" style="flex-basis:25%"></div>
-		<!-- /wp:column -->
-
-		<!-- wp:column {"width":"25%"} -->
-		<div class="wp-block-column" style="flex-basis:25%"></div>
-		<!-- /wp:column -->
-	</div>
-	<!-- /wp:columns -->
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+		<!-- /wp:separator -->
+	<!-- /wp:post-template -->
 
 	<!-- wp:group {"metadata":{"name":"Pagination"},"className":"wp-block-query-pagination__container","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
 	<div class="wp-block-group wp-block-query-pagination__container" style="margin-top:var(--wp--preset--spacing--80)">
-		<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-bottom:var(--wp--preset--spacing--30)"/>
-		<!-- /wp:separator -->
-
 		<!-- wp:query-pagination {"paginationArrow":"arrow","showLabel":false,"layout":{"type":"flex","justifyContent":"space-between"}} -->
 			<!-- wp:query-pagination-previous /-->
 

--- a/templates/archive-newspack_nl_cpt.html
+++ b/templates/archive-newspack_nl_cpt.html
@@ -1,0 +1,84 @@
+<!-- wp:template-part {"slug":"header","theme":"newspack-block-theme","tagName":"header"} /-->
+
+<!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"newspack_nl_cpt","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-query">
+
+	<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|30","margin":{"bottom":"var:preset|spacing|80"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+	<div class="wp-block-group" style="margin-bottom:var(--wp--preset--spacing--80)">
+		<!-- wp:query-title {"type":"archive","showPrefix":false} /-->
+
+		<!-- wp:term-description /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:columns {"align":"wide","className":"is-style-first-col-to-second"} -->
+	<div class="wp-block-columns alignwide is-style-first-col-to-second">
+		<!-- wp:column {"width":"50%","metadata":{"name":"Post"}} -->
+		<div class="wp-block-column" style="flex-basis:50%">
+			<!-- wp:post-template {"layout":{"type":"default"}} -->
+				<!-- wp:columns {"className":"is-style-first-col-to-second","style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+				<div class="wp-block-columns is-style-first-col-to-second" style="margin-top:0;margin-bottom:0">
+					<!-- wp:column {"width":"33.33%","metadata":{"name":"Image"}} -->
+					<div class="wp-block-column" style="flex-basis:33.33%">
+						<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+						<div class="wp-block-group">
+							<!-- wp:post-featured-image {"aspectRatio":"3/2","style":{"spacing":{"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
+							<!-- wp:newspack/featured-image-caption /-->
+						</div>
+						<!-- /wp:group -->
+					</div>
+					<!-- /wp:column -->
+
+					<!-- wp:column {"width":"66.66%","metadata":{"name":"Content"},"style":{"spacing":{"blockGap":"var:preset|spacing|20"}}} -->
+					<div class="wp-block-column" style="flex-basis:66.66%">
+						<!-- wp:group {"style":{"spacing":{"blockGap":"0"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+						<div class="wp-block-group">
+							<!-- wp:post-terms {"term":"category","fontSize":"small"} /-->
+
+							<!-- wp:post-title {"level":4,"isLink":true} /-->
+						</div>
+						<!-- /wp:group -->
+
+						<!-- wp:newspack-block-theme/article-subtitle {} /-->
+
+						<!-- wp:post-excerpt {"showMoreOnNewLine":false,"fontSize":"small"} /-->
+
+						<!-- wp:pattern {"slug":"newspack-block-theme/post-meta-compact"} /-->
+					</div>
+					<!-- /wp:column -->
+				</div>
+				<!-- /wp:columns -->
+			<!-- /wp:post-template -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"25%"} -->
+		<div class="wp-block-column" style="flex-basis:25%"></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"width":"25%"} -->
+		<div class="wp-block-column" style="flex-basis:25%"></div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:group {"metadata":{"name":"Pagination"},"className":"wp-block-query-pagination__container","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"},"blockGap":"var:preset|spacing|30"}},"layout":{"type":"default"}} -->
+	<div class="wp-block-group wp-block-query-pagination__container" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:separator {"className":"is-style-wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|30"}}}} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-bottom:var(--wp--preset--spacing--30)"/>
+		<!-- /wp:separator -->
+
+		<!-- wp:query-pagination {"paginationArrow":"arrow","showLabel":false,"layout":{"type":"flex","justifyContent":"space-between"}} -->
+			<!-- wp:query-pagination-previous /-->
+
+			<!-- wp:query-pagination-numbers {"midSize":1} /-->
+
+			<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+	</div>
+	<!-- /wp:group -->
+
+</main>
+<!-- /wp:query -->
+
+<!-- wp:template-part {"slug":"footer","theme":"newspack-block-theme","tagName":"footer"} /-->

--- a/templates/single-newspack_nl_cpt.html
+++ b/templates/single-newspack_nl_cpt.html
@@ -1,0 +1,30 @@
+<!-- wp:template-part {"slug":"header","theme":"newspack-block-theme","tagName":"header"} /-->
+
+<!-- wp:group {"tagName":"main","metadata":{"name":"Post"},"layout":{"type":"constrained"}} -->
+<main class="wp-block-group">
+
+	<!-- wp:pattern {"slug":"newspack-block-theme/post-header-style-1"} /-->
+
+	<!-- wp:group {"metadata":{"name":"Post Image"},"align":"full","className":"post-image","style":{"spacing":{"margin":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull post-image" style="margin-top:var(--wp--preset--spacing--80);margin-bottom:var(--wp--preset--spacing--80)">
+		<!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|20"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"stretch"}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-featured-image /-->
+			<!-- wp:newspack/featured-image-caption /-->
+		</div>
+		<!-- /wp:group -->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:group {"lock":{"move":false,"remove":true},"metadata":{"name":"Post Content"},"align":"full","style":{"spacing":{"margin":{"top":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
+	<div class="wp-block-group alignfull" style="margin-top:var(--wp--preset--spacing--80)">
+		<!-- wp:post-content {"lock":{"move":false,"remove":true},"align":"full","layout":{"type":"constrained"}} /-->
+	</div>
+	<!-- /wp:group -->
+
+	<!-- wp:template-part {"slug":"post-footer","theme":"newspack-block-theme","className":"post-footer"} /-->
+
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"newspack-block-theme","tagName":"footer"} /-->

--- a/theme.json
+++ b/theme.json
@@ -1169,6 +1169,20 @@
 				"post"
 			],
 			"title": "Single - Sidebar Layout"
+		},
+		{
+			"name": "single-newspack_nl_cpt",
+			"postTypes": [
+				"newspack_nl_cpt"
+			],
+			"title": "Single Newsletter"
+		},
+		{
+			"name": "archive-newspack_nl_cpt",
+			"postTypes": [
+				"newspack_nl_cpt"
+			],
+			"title": "Newsletter Archive"
 		}
 	],
 	"templateParts": [

--- a/theme.json
+++ b/theme.json
@@ -1169,20 +1169,6 @@
 				"post"
 			],
 			"title": "Single - Sidebar Layout"
-		},
-		{
-			"name": "single-newspack_nl_cpt",
-			"postTypes": [
-				"newspack_nl_cpt"
-			],
-			"title": "Single Newsletter"
-		},
-		{
-			"name": "archive-newspack_nl_cpt",
-			"postTypes": [
-				"newspack_nl_cpt"
-			],
-			"title": "Newsletter Archive"
 		}
 	],
 	"templateParts": [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds dedicated single and archive templates for the Newspack Newsletters custom post type (`newspack_nl_cpt`). This allows publishers who publish newsletters on their site to have newsletter-specific templates that can be customized independently in the Site Editor.

- **`single-newspack_nl_cpt.html`** — Identical to the existing `single.html` template. Provides a dedicated starting point for newsletter single post customization.
- **`archive-newspack_nl_cpt.html`** — Based on `archive.html` with the query `postType` set to `newspack_nl_cpt`. Lists only newsletter posts on the archive page with a simple post title + separator layout.
- **Template titles** — Templates appear as **"Single Newsletter"** and **"Newsletter Archive"** in the Site Editor. These titles are set via a `get_block_templates` PHP filter in `class-core.php` rather than `customTemplates` in `theme.json`, because WordPress auto-generates titles for standard hierarchy templates (e.g. `single-{post_type}`) from the post type label, and the `theme.json` entries do not override them.

[newsletter-templates-demo.webm](https://github.com/user-attachments/assets/a568e878-a850-4958-845c-5698abb70df1)

Closes https://linear.app/a8c/issue/NPPD-1321

### How to test the changes in this Pull Request:

1. Activate the block theme and Newspack Newsletters plugin.
2. Create a newsletter and mark it as public/published.
3. Visit the single newsletter URL — it should render using the dedicated single template.
4. Visit the newsletter archive URL (`/newsletter/`) — it should list only newsletter posts.
5. Open the Site Editor → Templates — verify that templates appear as **"Single Newsletter"** and **"Newsletter Archive"** (not the raw CPT slug).
6. Confirm that existing post single and archive templates are unaffected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?