### PR TITLE
fix: fine-tune code removing patterns to skip Woo Coming Soon patterns

### DIFF
--- a/includes/class-patterns.php
+++ b/includes/class-patterns.php
@@ -189,8 +189,8 @@ final class Patterns {
 				foreach ( $patterns as $pattern ) {
 					$should_remove = false;
 
-					// Preserve patterns required for the WooCommerce Coming Soon mode so they remain available for selection in the Site Editor.
-					if ( strpos( $pattern['name'], 'woocommerce/coming-soon' ) === 0 ) {
+					// Preserve patterns required for the WooCommerce Coming Soon mode — these need to remain in the inserter listing and stay registered globally so the template can render at runtime.
+					if ( self::is_woocommerce_coming_soon_pattern( $pattern['name'] ) ) {
 						continue;
 					}
 
@@ -245,7 +245,7 @@ final class Patterns {
 			// Preserve patterns required for the WooCommerce Coming Soon mode. These are
 			// referenced at render time by the coming-soon block template and must remain
 			// registered on the frontend.
-			if ( strpos( $pattern_name, 'woocommerce/coming-soon' ) === 0 ) {
+			if ( self::is_woocommerce_coming_soon_pattern( $pattern_name ) ) {
 				continue;
 			}
 
@@ -269,6 +269,22 @@ final class Patterns {
 	/**
 	 * WooCommerce-specific pattern handling methods.
 	 */
+
+	/**
+	 * Check whether a pattern name belongs to the WooCommerce Coming Soon chain.
+	 *
+	 * The `woocommerce/coming-soon` pattern resolves at runtime to either
+	 * `woocommerce/coming-soon-store-only` or `woocommerce/page-coming-soon-default`,
+	 * depending on the `woocommerce_store_pages_only` option. Both prefixes must be
+	 * preserved so the chain can render.
+	 *
+	 * @param string $pattern_name The pattern name to check.
+	 * @return bool
+	 */
+	private static function is_woocommerce_coming_soon_pattern( $pattern_name ) {
+		return strpos( $pattern_name, 'woocommerce/coming-soon' ) === 0
+			|| strpos( $pattern_name, 'woocommerce/page-coming-soon' ) === 0;
+	}
 
 	/**
 	 * Prevent WooCommerce patterns from being registered early.

--- a/includes/class-patterns.php
+++ b/includes/class-patterns.php
@@ -189,6 +189,11 @@ final class Patterns {
 				foreach ( $patterns as $pattern ) {
 					$should_remove = false;
 
+					// Preserve patterns required for the WooCommerce Coming Soon mode so they remain available for selection in the Site Editor.
+					if ( ! empty( $pattern['template_types'] ) || strpos( $pattern['name'], 'woocommerce/coming-soon' ) === 0 ) {
+						continue;
+					}
+
 					// Check if the pattern's name starts with any of the blacklisted prefixes.
 					foreach ( $blacklisted_pattern_prefixes as $prefix ) {
 						if ( strpos( $pattern['name'], $prefix ) === 0 ) {
@@ -236,6 +241,13 @@ final class Patterns {
 
 		foreach ( $patterns as $pattern ) {
 			$pattern_name = $pattern['name'];
+
+			// Preserve patterns required for the WooCommerce Coming Soon mode. These are
+			// referenced at render time by the coming-soon block template and must remain
+			// registered on the frontend.
+			if ( ! empty( $pattern['template_types'] ) || strpos( $pattern_name, 'woocommerce/coming-soon' ) === 0 ) {
+				continue;
+			}
 
 			// Check for various WooCommerce pattern naming conventions.
 			if ( strpos( $pattern_name, 'woocommerce' ) === 0 ||

--- a/includes/class-patterns.php
+++ b/includes/class-patterns.php
@@ -190,7 +190,7 @@ final class Patterns {
 					$should_remove = false;
 
 					// Preserve patterns required for the WooCommerce Coming Soon mode so they remain available for selection in the Site Editor.
-					if ( ! empty( $pattern['template_types'] ) || strpos( $pattern['name'], 'woocommerce/coming-soon' ) === 0 ) {
+					if ( strpos( $pattern['name'], 'woocommerce/coming-soon' ) === 0 ) {
 						continue;
 					}
 
@@ -245,7 +245,7 @@ final class Patterns {
 			// Preserve patterns required for the WooCommerce Coming Soon mode. These are
 			// referenced at render time by the coming-soon block template and must remain
 			// registered on the frontend.
-			if ( ! empty( $pattern['template_types'] ) || strpos( $pattern_name, 'woocommerce/coming-soon' ) === 0 ) {
+			if ( strpos( $pattern_name, 'woocommerce/coming-soon' ) === 0 ) {
 				continue;
 			}
 

--- a/newspack-block-theme
+++ b/newspack-block-theme
@@ -1,1 +1,0 @@
-/newspack-repos/newspack-block-theme

--- a/newspack-block-theme
+++ b/newspack-block-theme
@@ -1,0 +1,1 @@
+/newspack-repos/newspack-block-theme


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Block Theme currently has some code that removes all patterns registered outside of Newspack, to help simplify pattern selection and help focus publishers on what we've bundled.

This has had the unfortunately side-effect of obliterating WooCommerce's 'Coming Soon' page, as the pattern is not available on the front-end 😅 

This PR adds a check for those patterns specifically and makes sure they don't get removed. We may want to add our own version of this page in the future, but as is, it does the trick for now.

### How to test the changes in this Pull Request:

1. Ensure WooCommerce is in 'Coming Soon' mode (WooCommerce > Settings > Site Visibility)
2. In an incognito window, go to your /shop page; note nothing loads.
3. Apply this PR.
4. Refresh the incognito window; confirm you get the theme's header and footer, and a coming soon message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
