### PR TITLE
fix(block-theme): remove MJML image-caption filter moved to newsletters plugin

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -21,7 +21,6 @@ final class Newspack_Newsletters {
 			return;
 		}
 		\add_action( 'newspack_newsletters_enqueue_block_editor_assets', [ __CLASS__, 'enqueue_editor_styles' ] );
-		\add_filter( 'newspack_newsletters_mjml_component_attributes', [ __CLASS__, 'mjml_component_attributes' ] );
 	}
 
 	/**
@@ -29,21 +28,6 @@ final class Newspack_Newsletters {
 	 */
 	public static function enqueue_editor_styles() {
 		\add_editor_style( 'assets/css/newspack-newsletters-editor.css' );
-	}
-
-	/**
-	 * Custom MJML components attributes.
-	 *
-	 * @param array $attributes MJML component attributes.
-	 *
-	 * @return array MJML component attributes.
-	 */
-	public static function mjml_component_attributes( $attributes ) {
-		if ( isset( $attributes['css-class'] ) && 'image-caption' === $attributes['css-class'] ) {
-			$attributes['align']   = 'left';
-			$attributes['padding'] = '0';
-		}
-		return $attributes;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The MJML image-caption component attributes filter (setting `align=left` and `padding=0`) was duplicated identically in both the block theme and classic theme. This code has been moved into the newsletters plugin renderer as a default in Automattic/newspack-newsletters#2078, so the duplicate in this theme is no longer needed.

Depends on Automattic/newspack-newsletters#2078

Addresses https://linear.app/a8c/issue/NPPD-1316

### How to test the changes in this Pull Request:

1. Apply Automattic/newspack-newsletters#2078 first
2. Activate the Newspack Block Theme
3. Create a Newsletter post with all of the non-RDB blocks (I decided not to tackle these here as this one is already quite hairy) listed in [this comment](https://linear.app/a8c/issue/NPPD-1316/newsletter-newsletter-editor-testing#comment-f5f59aa6)
4. Send a test email and verify the image caption is left-aligned with no extra padding — same as before this change

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)