### PR TITLE
fix: remove italics from editor preview for subtitle block

### DIFF
--- a/includes/blocks/subtitle-block/post-editor.js
+++ b/includes/blocks/subtitle-block/post-editor.js
@@ -38,7 +38,6 @@ const appendSubtitleToTitleDOMElement = ( subtitle, editorDoc, callback ) => {
 			style.id = SUBTITLE_STYLE_ID;
 			style.innerHTML = `
                 #${ SUBTITLE_ID } {
-                    font-style: italic;
                     max-width: calc(var(--wp--style--global--content-size, 632px) + var(--wp--preset--spacing--30)* 2);
                     margin-left: auto;
                     margin-right: auto;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes italics from the post editor preview of the subtitle block.

Closes NPPD-1456

### How to test the changes in this Pull Request:

1. Edit a post in the block editor, and add a subtitle (note: it's not italicized in the site editor, just the post editor).
2. Note the text is italicized, even though it's not on the front end.
3. Apply this PR and run `npm run build`.
4. Confirm the subtitle is no longer italicized in the post editor.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
