### PR TITLE
fix(theme): square icon-only buttons via theme.json variations

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -971,6 +971,48 @@
 					"fontSize": "var( --wp--preset--font-size--x-small )",
 					"lineHeight": "var( --wp--custom--line-height--x-small )"
 				}
+			},
+			"newspack/my-account-button": {
+				"variations": {
+					"icon-only": {
+						"spacing": {
+							"padding": {
+								"bottom": "var( --wp--custom--spacing--25 )",
+								"left": "var( --wp--custom--spacing--25 )",
+								"right": "var( --wp--custom--spacing--25 )",
+								"top": "var( --wp--custom--spacing--25 )"
+							}
+						}
+					}
+				}
+			},
+			"newspack/overlay-menu-trigger": {
+				"variations": {
+					"icon-only": {
+						"spacing": {
+							"padding": {
+								"bottom": "var( --wp--custom--spacing--25 )",
+								"left": "var( --wp--custom--spacing--25 )",
+								"right": "var( --wp--custom--spacing--25 )",
+								"top": "var( --wp--custom--spacing--25 )"
+							}
+						}
+					}
+				}
+			},
+			"newspack/overlay-search": {
+				"variations": {
+					"icon-only": {
+						"spacing": {
+							"padding": {
+								"bottom": "var( --wp--custom--spacing--25 )",
+								"left": "var( --wp--custom--spacing--25 )",
+								"right": "var( --wp--custom--spacing--25 )",
+								"top": "var( --wp--custom--spacing--25 )"
+							}
+						}
+					}
+				}
 			}
 		},
 		"color": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-block-theme/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a square padding default for the `icon-only` style variation of three Newspack blocks via `theme.json` `styles.blocks.<name>.variations.icon-only`:

- `newspack/overlay-search`
- `newspack/overlay-menu-trigger`
- `newspack/my-account-button`

All four padding sides resolve to `var( --wp--custom--spacing--25 )` (0.75rem), so when the user selects the **Icon only** block style and doesn't customize spacing, the button renders as a square box with the icon centered.

#### Why theme.json instead of plugin CSS

The token `--wp--custom--spacing--25` is defined in this theme — putting the rule in the block theme keeps responsibility where the token lives. Per-pattern padding overrides (block-supports inline `style="padding-*: …"`) still win on a per-side basis, so existing patterns that customize padding for icon-only buttons keep their explicit values.

#### Companion plugin change

Depends on [`Automattic/newspack-plugin#4729`](https://github.com/Automattic/newspack-plugin/pull/4729), which moves the `icon-only` style registration for these three blocks from JS-only \`registerBlockStyle()\` to server-side \`block.json\` \`styles\` arrays. \`theme.json\` variation compilation runs server-side and only emits CSS for variations it can see at boot — without the plugin change, the rules in this PR would be silently dropped.

### How to test the changes in this Pull Request:

1. Pull both branches:
   - This branch in `newspack-block-theme`
   - `feat/search-overlay-block` in `newspack-plugin`
2. Activate Newspack Block Theme and the plugin.
3. In the Site Editor, drop in an **Overlay Search**, **Overlay Menu Trigger**, or **My Account Button** block.
4. Set the block style to **Icon only**.
5. View on the frontend → the button should render as a square box (0.75rem padding all sides), icon centered.
6. Confirm respect for user overrides:
   - In the editor, set a custom padding on one side via the Dimensions panel.
   - Save and view → the customized side wins; the other three sides keep the 0.75rem default.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?